### PR TITLE
Enable HSTS for all apache served SSL sites

### DIFF
--- a/cookbooks/apache/recipes/ssl.rb
+++ b/cookbooks/apache/recipes/ssl.rb
@@ -29,6 +29,7 @@ apache_module "socache_shmcb" do
 end
 
 apache_module "ssl"
+apache_module "headers"
 
 apache_conf "ssl" do
   template "ssl.erb"

--- a/cookbooks/apache/templates/default/ssl.erb
+++ b/cookbooks/apache/templates/default/ssl.erb
@@ -8,10 +8,14 @@ SSLCipherSuite aRSA+HIGH:+kEDH:+kRSA:!kSRP:!kPSK:+3DES:!MD5
 SSLCertificateFile /etc/ssl/certs/<%= @certificate %>.pem
 SSLCertificateKeyFile /etc/ssl/private/<%= @certificate %>.key
 SSLCertificateChainFile /etc/ssl/certs/rapidssl.pem
-<% if node[:lsb][:release].to_f >= 14.04 -%>
 
+<% if node[:lsb][:release].to_f >= 14.04 -%>
 SSLUseStapling On
 SSLStaplingResponderTimeout 5
 SSLStaplingReturnResponderErrors off
 SSLStaplingCache shmcb:${APACHE_RUN_DIR}/ssl_ocspcache(512000)
+
+Header setifempty Strict-Transport-Security max-age=86400 env=HTTPS
+<% else -%>
+Header set Strict-Transport-Security max-age=86400 env=HTTPS
 <% end -%>


### PR DESCRIPTION
This enables [HTTP Strict Transport Security](http://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security) for all our apache served SSL sites.

This basically means that we tell the browser to default to using https for those sites even if the user types http, until a given expiry date. Currently I have set that 180 days but that is open for discussion.
