### PR TITLE
Disable deprecated SSLv3 (POODLE fix)

### DIFF
--- a/cookbooks/tilecache/templates/default/nginx_tile_ssl.conf.erb
+++ b/cookbooks/tilecache/templates/default/nginx_tile_ssl.conf.erb
@@ -7,7 +7,7 @@ server {
     ssl_certificate      /etc/ssl/certs/<%= @certificate %>.pem;
     ssl_certificate_key  /etc/ssl/private/<%= @certificate %>.key;
 
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2 SSLv3;
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
     ssl_ciphers aRSA+HIGH:+kEDH:+kRSA:!kSRP:!kPSK:+3DES:!MD5;
     ssl_prefer_server_ciphers on;
     ssl_session_cache shared:SSL:30m;


### PR DESCRIPTION
The SSLv3 protocol is considered deprecated and dangerous due to known security vulnerabillities (POODLE). Major webpages (e.g. twitter) and browsers (firefox, chromium will follow) have recently disabled SSLv3. OSM should do, too (apache template config already does).

This issus is currently a reason why osm tile servers get a bad rating on the Qualys SSL Labs test. The other major issue is a certificate signed with sha-1, which should be replaced as soon as possible.
