### PR TITLE
Bump planet-dump-ng version for bug fix.

### DIFF
--- a/cookbooks/planet/recipes/dump.rb
+++ b/cookbooks/planet/recipes/dump.rb
@@ -55,7 +55,7 @@ end
 git "/opt/planet-dump-ng" do
   action :sync
   repository "git://github.com/zerebubuth/planet-dump-ng.git"
-  revision "v1.0.0"
+  revision "v1.0.1"
   user "root"
   group "root"
 end


### PR DESCRIPTION
Version 1.0.1 of planet-dump-ng contains a bug fix which could leave the program in a hung state indefinitely due to poor design of inter-thread communication. Threads finishing would set their index and call the main thread to wake up, but if the main thread didn't wake up before a second thread finished then the first notification would be lost.