### PR TITLE
Add changeset comment dumps.

### DIFF
--- a/cookbooks/planet/recipes/dump.rb
+++ b/cookbooks/planet/recipes/dump.rb
@@ -55,7 +55,7 @@ end
 git "/opt/planet-dump-ng" do
   action :sync
   repository "git://github.com/zerebubuth/planet-dump-ng.git"
-  revision "v1.0.1"
+  revision "v1.1.0"
   user "root"
   group "root"
 end

--- a/cookbooks/planet/templates/default/planetdump.erb
+++ b/cookbooks/planet/templates/default/planetdump.erb
@@ -69,6 +69,7 @@ rm -rf relations relation_tags relation_members
 time nice -n 19 /opt/planet-dump-ng/planet-dump-ng \
      -c "pbzip2 -c" -f "/store/backup/${file}" --dense-nodes=1 \
      -C "changesets-${date}.osm.bz2" \
+     -D "discussions-${date}.osm.bz2" \
      -x "planet-${date}.osm.bz2" -X "history-${date}.osm.bz2" \
      -p "planet-${date}.osm.pbf" -P "history-${date}.osm.pbf"
 
@@ -91,6 +92,7 @@ function install_dump {
 
 # Move dumps into place
 install_dump "changesets" "bz2" "<%= node[:planet][:dump][:xml_directory] %>" "${year}"
+install_dump "discussions" "bz2" "<%= node[:planet][:dump][:xml_directory] %>" "${year}"
 install_dump "planet" "bz2" "<%= node[:planet][:dump][:xml_directory] %>" "${year}"
 install_dump "history" "bz2" "<%= node[:planet][:dump][:xml_history_directory] %>" "${year}"
 install_dump "planet" "pbf" "<%= node[:planet][:dump][:pbf_directory] %>"


### PR DESCRIPTION
This bumps the version of `planet-dump-ng` to 1.1.0, the first version capable of dumping changeset comments. The comments are included with the changesets, but for the moment dumped to a separate file called "discussions" while we give anyone who depends on the old format a chance to update their parsers.