### PR TITLE
Archive cgimap logs to ironbelly.

### DIFF
--- a/cookbooks/web/templates/default/logrotate.web.erb
+++ b/cookbooks/web/templates/default/logrotate.web.erb
@@ -18,6 +18,7 @@
 <% end -%>
 <% if File.directory?("#{node[:web][:base_directory]}/cgimap") -%>
     /usr/bin/service cgimap reload
+    /usr/bin/rsync <%= node[:web][:log_directory] %>/cgimap.log.2.gz ironbelly::logs/www.openstreetmap.org/cgimap-<%= node[:hostname] %>-`date -d "-2 days" +%Y-%m-%d`.gz
 <% end -%>
   endscript
 }


### PR DESCRIPTION
Currently these aren't archived, meaning we can't investigate issues which occurred more than 7 days ago. Nor can we do a long-term historical analysis of the logs to figure out the best values for, e.g: rate limiting parameters.
