### PR TITLE
The changeset comments temporary should be cleaned too.

### DIFF
--- a/cookbooks/planet/templates/default/planetdump.erb
+++ b/cookbooks/planet/templates/default/planetdump.erb
@@ -60,7 +60,7 @@ cd /store/planetdump
 
 # Cleanup
 rm -rf users
-rm -rf changesets changeset_tags
+rm -rf changesets changeset_tags changeset_comments
 rm -rf nodes node_tags
 rm -rf ways way_tags way_nodes
 rm -rf relations relation_tags relation_members


### PR DESCRIPTION
This is the cause of, and fixes zerebubuth/planet-dump-ng#12 - the temporary data for changeset comments dates from February.

I had thought that having the temporaries resumable would make sense, but it seems that it's more confusing to have it keep old data around like that...