### PR TITLE
Bump planet-dump-ng to latest version.

### DIFF
--- a/cookbooks/planet/recipes/dump.rb
+++ b/cookbooks/planet/recipes/dump.rb
@@ -55,7 +55,7 @@ end
 git "/opt/planet-dump-ng" do
   action :sync
   repository "git://github.com/zerebubuth/planet-dump-ng.git"
-  revision "v1.1.0"
+  revision "v1.1.1"
   user "root"
   group "root"
 end


### PR DESCRIPTION
Latest version is a small change: default behaviour is now to remove any old data and start from scratch, rather than resuming processing using old data. This seems like saner behaviour.