### PR TITLE
Bump planet-dump-ng version for work-around.

### DIFF
--- a/cookbooks/planet/recipes/dump.rb
+++ b/cookbooks/planet/recipes/dump.rb
@@ -55,7 +55,7 @@ end
 git "/opt/planet-dump-ng" do
   action :sync
   repository "git://github.com/zerebubuth/planet-dump-ng.git"
-  revision "v1.1.1"
+  revision "v1.1.2"
   user "root"
   group "root"
 end


### PR DESCRIPTION
The `planet-dump-ng` program only checks periodically for overflow of the maximum block size allowed by the OSM PBF format. This is too infrequent to catch the 2,000 relations which are >24MB, and the block overflows and causes the process to halt. This work-around just reduces that limit to 500 elements, and has been tested and works for the previous planet. This isn't a real fix, but doing it "properly" (i.e: testing for overflow _before_ each relation is added) is more complex due to rolling back additions to the string table and so forth.