### PR TITLE
Allow pinning kernel versions to work around hardware / driver issues.

### DIFF
--- a/cookbooks/hardware/attributes/default.rb
+++ b/cookbooks/hardware/attributes/default.rb
@@ -1,5 +1,6 @@
 default[:hardware][:modules] = %w(loop lp rtc)
 default[:hardware][:grub][:cmdline] = %w(nomodeset)
+default[:hardware][:grub][:kernel] = :latest
 default[:hardware][:sensors] = {}
 
 if node[:dmi] && node[:dmi][:system]

--- a/cookbooks/hardware/recipes/default.rb
+++ b/cookbooks/hardware/recipes/default.rb
@@ -127,6 +127,7 @@ end
 unless node[:hardware][:grub][:kernel] == :latest
   package "linux-image-#{node[:hardware][:grub][:kernel]}-generic"
   package "linux-image-extra-#{node[:hardware][:grub][:kernel]}-generic"
+  package "linux-headers-#{node[:hardware][:grub][:kernel]}-generic"
 end
 
 if File.exist?("/etc/default/grub")

--- a/cookbooks/hardware/recipes/default.rb
+++ b/cookbooks/hardware/recipes/default.rb
@@ -120,6 +120,15 @@ unless unit.nil?
   end
 end
 
+# if we need a different / special kernel version to make the hardware
+# work (e.g: https://github.com/openstreetmap/operations/issues/45) then
+# ensure that we have the package installed. the grub template will
+# make sure that this is the default on boot.
+unless node[:hardware][:grub][:kernel] == :latest
+  package "linux-image-#{node[:hardware][:grub][:kernel]}-generic"
+  package "linux-image-extra-#{node[:hardware][:grub][:kernel]}-generic"
+end
+
 if File.exist?("/etc/default/grub")
   execute "update-grub" do
     action :nothing

--- a/cookbooks/hardware/templates/default/grub.erb
+++ b/cookbooks/hardware/templates/default/grub.erb
@@ -4,8 +4,19 @@
 # it to boot a specific version.
 <% if node[:hardware][:grub][:kernel] == :latest %>
 GRUB_DEFAULT="0"
-<% else %>
-GRUB_DEFAULT="Ubuntu, with Linux <%= node[:hardware][:grub][:kernel] %>-generic"
+<% else
+  df = Mixlib::ShellOut.new("df /boot/grub/grub.cfg | tail -n 1 | awk '{print $1;}'")
+  df.run_command
+  df.error!
+  root=df.stdout
+
+  blkid = Mixlib::ShellOut.new("blkid -o value -s UUID #{root}")
+  blkid.run_command
+  blkid.error!
+  uuid=blkid.stdout
+
+  version="#{node[:hardware][:grub][:kernel]}-generic" %>
+GRUB_DEFAULT="gnulinux-advanced-<%= uuid %>>gnulinux-<%= version %>-advanced-<%= uuid %>"
 <% end %>
 
 # Wait two seconds before booting the default entry

--- a/cookbooks/hardware/templates/default/grub.erb
+++ b/cookbooks/hardware/templates/default/grub.erb
@@ -1,7 +1,12 @@
 # DO NOT EDIT - This file is being maintained by Chef
 
-# Boot the first entry by default
+# Boot the first entry by default, unless we have configured
+# it to boot a specific version.
+<% if node[:hardware][:grub][:kernel] == :latest %>
 GRUB_DEFAULT="0"
+<% else %>
+GRUB_DEFAULT="Ubuntu, with Linux <%= node[:hardware][:grub][:kernel] %>-generic"
+<% end %>
 
 # Wait two seconds before booting the default entry
 GRUB_TIMEOUT="2"

--- a/roles/pummelzacken.rb
+++ b/roles/pummelzacken.rb
@@ -50,6 +50,14 @@ default_attributes(
       }
     },
     :redirects => {}
+  },
+  :hardware => {
+    :grub => {
+      # lock kernel to 3.16.0-46 due to some issue with igb driver
+      # see https://github.com/openstreetmap/operations/issues/45
+      # for more information.
+      :kernel => "3.16.0-46"
+    }
   }
 )
 


### PR DESCRIPTION
Sometimes hardware issues or driver issues are fixed or broken in specific kernel versions, so it's handy to be able to pin the version to a known-working one while the problem is sorted out or a proper fix is found.

This does this by ensuring that the particular kernel version package is installed and that the grub configuration boots that as the default.

For context, see:

https://github.com/openstreetmap/operations/issues/45