### PR TITLE
Deconfigure smaug to make way for a new machine.

### DIFF
--- a/roles/smaug.rb
+++ b/roles/smaug.rb
@@ -29,16 +29,6 @@ default_attributes(
       }
     }
   },
-  :networking => {
-    :interfaces => {
-      :internal_ipv4 => {
-        :interface => "eth0",
-        :role => :internal,
-        :family => :inet,
-        :address => "146.179.159.168"
-      }
-    }
-  },
   :postgresql => {
     :settings => {
       :defaults => {
@@ -72,6 +62,5 @@ default_attributes(
 )
 
 run_list(
-  "role[ic]",
-  "role[db-slave]"
+  "role[ucl]"
 )


### PR DESCRIPTION
Smaug was moved back to UCL and is currently not powered up. Meanwhile, smaug's IP has been re-used for another machine which I can't log into because smaug's SSH key is still in known_hosts.