### PR TITLE
Add unattended upgrades support

### DIFF
--- a/cookbooks/apt/attributes/default.rb
+++ b/cookbooks/apt/attributes/default.rb
@@ -1,1 +1,3 @@
 default_unless[:apt][:sources] = []
+default[:apt][:unattended_upgrades][:enable] = true
+default[:apt][:unattended_upgrades][:remove_unused_dependencies] = false

--- a/cookbooks/apt/recipes/default.rb
+++ b/cookbooks/apt/recipes/default.rb
@@ -19,6 +19,7 @@
 
 package "apt"
 package "update-notifier-common"
+package "debconf-utils"
 
 file "/etc/motd.tail" do
   action :delete
@@ -108,4 +109,23 @@ apt_source "postgresql" do
   template "postgresql.list.erb"
   url "http://apt.postgresql.org/pub/repos/apt"
   key "ACCC4CF8"
+end
+
+package "unattended-upgrades" do
+  response_file "unattended-upgrades.seed.erb"
+  action :install
+end
+
+# Not idempotent - reconfig runs every time, required if package previously installed without response_file or response_file changes
+package "unattended-upgrades_reconfig" do
+  package_name "unattended-upgrades"
+  response_file "unattended-upgrades.seed.erb"
+  action :reconfig
+end
+
+template "/etc/apt/apt.conf.d/60chef" do
+  source "apt.conf.erb"
+  owner "root"
+  group "root"
+  mode 0644
 end

--- a/cookbooks/apt/templates/default/apt.conf.erb
+++ b/cookbooks/apt/templates/default/apt.conf.erb
@@ -1,0 +1,5 @@
+// DO NOT EDIT - This file is being maintained by Chef
+
+// Do automatic removal of new unused dependencies after the upgrade
+// (equivalent to apt-get autoremove)
+Unattended-Upgrade::Remove-Unused-Dependencies "<%= node['apt']['unattended_upgrades']['remove_unused_dependencies'] ? 'true' : 'false' %>";

--- a/cookbooks/apt/templates/default/unattended-upgrades.seed.erb
+++ b/cookbooks/apt/templates/default/unattended-upgrades.seed.erb
@@ -1,0 +1,1 @@
+unattended-upgrades unattended-upgrades/enable_auto_updates boolean <%= node['apt']['unattended_upgrades']['enable'] ? 'true' : 'false' %>

--- a/roles/db.rb
+++ b/roles/db.rb
@@ -10,6 +10,12 @@ default_attributes(
       }
     }
   },
+  :apt => {
+    :unattended_upgrades => {
+      :enable => false,
+      :remove_unused_dependencies => false
+    }
+  },
   :munin => {
     :plugins => {
       :postgres_connections_openstreetmap => {

--- a/roles/katie.rb
+++ b/roles/katie.rb
@@ -2,6 +2,11 @@ name "katie"
 description "Master role applied to katie"
 
 default_attributes(
+  :apt => {
+    :unattended_upgrades => {
+      :remove_unused_dependencies => true
+    }
+  },
   :networking => {
     :interfaces => {
       :external_ipv4 => {


### PR DESCRIPTION
Bring unattended-upgrades support into chef. Many of the servers already have unattended-upgrades installed and partially configured.

By default enable, specifically disable on DB role machines.

Also added "Unattended-Upgrade::Remove-Unused-Dependencies" support, which is primarily used for removing unused kernel packages. (automatically keeps current running kernel + last run + latest)