### PR TITLE
Bump planet dump version to 1.1.3 for char replacement fix.

### DIFF
--- a/cookbooks/planet/recipes/dump.rb
+++ b/cookbooks/planet/recipes/dump.rb
@@ -55,7 +55,7 @@ end
 git "/opt/planet-dump-ng" do
   action :sync
   repository "git://github.com/zerebubuth/planet-dump-ng.git"
-  revision "v1.1.2"
+  revision "v1.1.3"
   user "root"
   group "root"
 end


### PR DESCRIPTION
Refs https://github.com/zerebubuth/openstreetmap-changeset-replication/issues/3.