### PR TITLE
Spaces (0x20) should not be replaced, as they are not invalid.

### DIFF
--- a/cookbooks/planet/files/default/replication-bin/replicate-changesets
+++ b/cookbooks/planet/files/default/replication-bin/replicate-changesets
@@ -18,7 +18,7 @@ GEO_SCALE = 10000000
 ##
 # replace characters which cannot be represented in XML 1.0.
 def xml_sanitize(str)
-  str.gsub(/[\x00-\x08\x0b\x0c\x0e-\x20]/, "?")
+  str.gsub(/[\x00-\x08\x0b\x0c\x0e-\x1f]/, "?")
 end
 
 ##


### PR DESCRIPTION
Thanks to @pa5cal for pointing this out and filing https://github.com/zerebubuth/openstreetmap-changeset-replication/issues/4.