### PR TITLE
Reduce tile log analysis delay.

### DIFF
--- a/cookbooks/tilecache/templates/default/logrotate.squid.erb
+++ b/cookbooks/tilecache/templates/default/logrotate.squid.erb
@@ -12,6 +12,6 @@
   sharedscripts
   postrotate
     test ! -e /var/run/squid.pid || /usr/sbin/squid -k rotate
-    /usr/bin/rsync /var/log/squid/zere.log.2.xz ironbelly::logs/tile.openstreetmap.org/<%= node[:hostname] %>-`date -d "-2 days" +%Y-%m-%d`.xz || true
+    /usr/bin/rsync /var/log/squid/zere.log.1.xz ironbelly::logs/tile.openstreetmap.org/<%= node[:hostname] %>-`date -d "-1 days" +%Y-%m-%d`.xz || true
   endscript
 }

--- a/cookbooks/tilelog/templates/default/tilelog.erb
+++ b/cookbooks/tilelog/templates/default/tilelog.erb
@@ -4,7 +4,7 @@ ANALYZE=<%= @analyze_bin %>
 LOGDIR=<%= @input_dir %>
 OUTDIR=<%= @output_dir %>
 if [ -z "$DATE" ]; then
-		DATE=`date -d "2 days ago" "+%Y-%m-%d"`
+		DATE=`date -d "1 day ago" "+%Y-%m-%d"`
 fi
 TMPDIR=`mktemp -d -t tmp.XXXXXXXXX`
 ORIGDIR=`pwd`


### PR DESCRIPTION
Take yesterday's squid logs for analysis rather than two days ago.

@Firefishy - I think there was a reason why we were taking 2 days ago, but I can't figure it out now. Seems to me that this would work okay, as the logs should be rotated at 0625, compressed and uploaded, then the analysis will run at 1722. Ten hours to compress and upload should be enough, right?
