### PR TITLE
link new 'Wiki content license' page in the footer

### DIFF
--- a/cookbooks/mediawiki/templates/default/LocalSettings.php.erb
+++ b/cookbooks/mediawiki/templates/default/LocalSettings.php.erb
@@ -141,7 +141,7 @@ $wgDefaultSkin = "<%= @mediawiki[:skin] %>";
 ## For attaching licensing metadata to pages, and displaying an
 ## appropriate copyright notice / icon. GNU Free Documentation
 ## License and Creative Commons licenses are supported so far.
-$wgRightsPage = "OpenStreetMap_License"; # Set to the title of a wiki page that describes your license/copyright
+$wgRightsPage = "Wiki_content_license"; # Set to the title of a wiki page that describes your license/copyright
 $wgRightsUrl  = "http://creativecommons.org/licenses/by-sa/2.0/";
 $wgRightsText = "Creative Commons Attribution-ShareAlike 2.0 license";
 $wgRightsIcon = "/cc-wiki.png";


### PR DESCRIPTION
The current wiki footer link, takes us to http://wiki.openstreetmap.org/wiki/OpenStreetMap_License  which no longer has any information about the wiki content license, so potentially misleading. We've created a new page 'Wiki content license' to be a better destination for that footer link . Some more discussion here: http://wiki.openstreetmap.org/wiki/Talk:OpenStreetMap_License

Swapping this `$wgRightsPage` value should do the trick