### PR TITLE
Add server location description to aws

### DIFF
--- a/roles/aws.rb
+++ b/roles/aws.rb
@@ -2,6 +2,8 @@ name "aws"
 description "Role applied to all servers on AWS"
 
 default_attributes(
+  :hosted_by => "AWS",
+  :location => "Ireland",
   :networking => {
     :nameservers => ["172.31.0.2"],
     :roles => {


### PR DESCRIPTION
I couldn't find anywhere more specific than just "Ireland" for the AWS datacentres.