### PR TITLE
Bump version of planet-dump-ng to get fixes for long changeset comments.

### DIFF
--- a/cookbooks/planet/recipes/dump.rb
+++ b/cookbooks/planet/recipes/dump.rb
@@ -55,7 +55,7 @@ end
 git "/opt/planet-dump-ng" do
   action :sync
   repository "git://github.com/zerebubuth/planet-dump-ng.git"
-  revision "v1.1.3"
+  revision "v1.1.4"
   user "root"
   group "root"
 end


### PR DESCRIPTION
Version 1.1.3 of `planet-dump-ng` was not able to handle text fields greater than 64kB in length. Previously, this hadn't been a problem but [changeset 39766630](http://www.openstreetmap.org/changeset/39766630) has a comment 95kB in length.

Version 1.1.4 of `planet-dump-ng` fixes this, and it should now be able to support much larger comments.
