### PR TITLE
Explicitly set number of osm2pgsql processes

### DIFF
--- a/cookbooks/tile/templates/default/replicate.erb
+++ b/cookbooks/tile/templates/default/replicate.erb
@@ -68,9 +68,9 @@ do
 
             # Apply the changes to the database
 <% if node[:tile][:node_file] -%>
-            osm2pgsql --slim --append --flat-nodes=<%= node[:tile][:node_file] %> ${file}
+            osm2pgsql --slim --append --number-processes 1 --flat-nodes=<%= node[:tile][:node_file] %> ${file}
 <% else -%>
-            osm2pgsql --slim --append ${file}
+            osm2pgsql --slim --append --number-processes 1 ${file}
 <% end -%>
 
             # No need to rollback now


### PR DESCRIPTION
Old versions of osm2pgsql default to ``--number-processes 1``, but new versions default to the number of physical threads. On a production server where osm2pgsql, the DB and Mapnik are all run on one machine it can be desirable to reduce this during updates to keep more resources available for rendering.

This change is in the expectation of moving to a more recent system with a more recent osm2pgsql at some point in the future.

I would go for 2-4 processes, except old versions of osm2pgsql have bugs with multi-process updates.

This specific patch is untested, since I don't have a setup to test it on.