### PR TITLE
Add test-kitchen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.kitchen/

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,14 @@
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_zero
+
+platforms:
+  - name: ubuntu-16.04
+
+suites:
+  - name: tools
+    run_list:
+      - recipe[tools::default]

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source "https://rubygems.org"
 
 gem "rubocop"
 gem "foodcritic"
+gem "test-kitchen"
+gem "kitchen-vagrant"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    artifactory (2.3.3)
     ast (2.3.0)
     cucumber-core (1.5.0)
       gherkin (~> 4.0)
@@ -14,7 +15,18 @@ GEM
       treetop (~> 1.4)
       yajl-ruby (~> 1.1)
     gherkin (4.0.0)
+    kitchen-vagrant (0.20.0)
+      test-kitchen (~> 1.4)
     mini_portile2 (2.1.0)
+    mixlib-install (1.1.0)
+      artifactory
+      mixlib-shellout
+      mixlib-versioning
+    mixlib-shellout (2.2.6)
+    mixlib-versioning (1.1.0)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-ssh (3.2.0)
     nokogiri (1.6.8)
       mini_portile2 (~> 2.1.0)
       pkg-config (~> 1.1.7)
@@ -33,6 +45,15 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
     rufus-lru (1.1.0)
+    safe_yaml (1.0.4)
+    test-kitchen (1.10.2)
+      mixlib-install (~> 1.0, >= 1.0.4)
+      mixlib-shellout (>= 1.2, < 3.0)
+      net-scp (~> 1.1)
+      net-ssh (>= 2.9, < 4.0)
+      safe_yaml (~> 1.0)
+      thor (~> 0.18)
+    thor (0.19.1)
     treetop (1.6.5)
       polyglot (~> 0.3)
     unicode-display_width (1.1.0)
@@ -43,7 +64,9 @@ PLATFORMS
 
 DEPENDENCIES
   foodcritic
+  kitchen-vagrant
   rubocop
+  test-kitchen
 
 BUNDLED WITH
-   1.10.6
+   1.11.2


### PR DESCRIPTION
This initial configuration uses kitchen-vagrant to test the tools cookbook.

I tried, and failed^Whaven't yet succeeded in getting more complex cookbooks to run, so I fell back on a pretty simple cookbook. Even then, there were challenges getting it to work with kitchen-docker, so I stuck with kitchen-vagrant for now.

The choice of a global test-kitchen setup vs a per-cookbook setup is not my first preference. Unfortunately there's no straightforward way to implement anything else, given our mono-repo and not using any cookbook publication systems. Using a global test-kitchen config is also the result that @zerebubuth came up with independently during work in June.