### PR TITLE
Block fastpokemap, currently 13% of tile usage.

### DIFF
--- a/cookbooks/tilecache/templates/default/squid.conf.erb
+++ b/cookbooks/tilecache/templates/default/squid.conf.erb
@@ -28,6 +28,8 @@ http_access deny osmtile_sites osmtileScrapers
 
 acl osmtileOverusers referer_regex ^https?://pmap\.kuku\.lu/
 acl osmtileOverusers referer_regex ^https?://[^.]*\.pmap\.kuku\.lu/
+acl osmtileOverusers referer_regex ^https?://fastpokemap\.com/
+acl osmtileOverusers referer_regex ^https?://[^.]*\.fastpokemap\.com/
 
 http_access deny osmtile_sites osmtileOverusers
 


### PR DESCRIPTION
The extra load appears to be a major contributory factor to slow tile loading and the general melting of tile servers.

The owner of the site was contacted a short time ago, probably not long enough to have reacted yet. The site is definitely in violation of the [acceptable use policy](http://wiki.openstreetmap.org/wiki/Tile_usage_policy).

The question is; should we go ahead with the block immediately, or give some grace period?