### PR TITLE
Swap wiki sign up to use google ReCaptchaNoCaptcha

### DIFF
--- a/cookbooks/mediawiki/templates/default/mw-ext-ConfirmEdit.inc.php.erb
+++ b/cookbooks/mediawiki/templates/default/mw-ext-ConfirmEdit.inc.php.erb
@@ -1,7 +1,8 @@
 <?php
 # DO NOT EDIT - This file is being maintained by Chef
-wfLoadExtensions( array( 'ConfirmEdit', 'ConfirmEdit/ReCaptcha' ) );
-$wgCaptchaClass = 'ReCaptcha';
+wfLoadExtensions( array( 'ConfirmEdit', 'ConfirmEdit/ReCaptchaNoCaptcha' ) );
+$wgCaptchaClass = 'ReCaptchaNoCaptcha';
+$wgReCaptchaSendRemoteIP = true;
 $recaptcha_public_key = '<%= @public_key %>';
 $recaptcha_private_key = '<%= @private_key %>';
 


### PR DESCRIPTION
Swap to the more modern google No CAPTCHA reCAPTCHA away from the older google reCAPTCHA which gathers address data for google maps.

Fixes: https://github.com/openstreetmap/operations/issues/19

This simple config swap assumes...
* The recent ConfirmEdit version we have installed (1.4) comes with all the necessary bits to enable this captcha class
* Google's old ReCaptcha uses the same API keys as it's new one (anyone know if this is true?)

risky assumptions? well we could make the swap then swap it back again if wiki sign ups are broken. ...or test in a better way somehow

TODO: in future we might figure out a solution which _also_ doesn't request any javascript from google, but really... not contributing to google maps with every OSM wiki sign up would be a step in the right direction