### PR TITLE
Forward authentication headers on to the backends

### DIFF
--- a/cookbooks/web/templates/default/apache.frontend.erb
+++ b/cookbooks/web/templates/default/apache.frontend.erb
@@ -176,6 +176,11 @@
   ProxyTimeout 3600
 
   #
+  # Forward authentication headers to the backends
+  #
+  SetEnv proxy-chain-auth On
+
+  #
   # Allow all proxy requests
   #
   <Proxy *>


### PR DESCRIPTION
So that they can check them. The default behaviour appears to be that [it strips out auth-related headers](https://httpd.apache.org/docs/current/mod/mod_proxy_http.html#env), which would be appropriate if it were forwarding information over the internet, but it isn't.

I suspect this may be why cgimap is having trouble detecting the authentication headers.