### PR TITLE
Pass authorisation headers to cgimap so that it can handle OAuth.

### DIFF
--- a/cookbooks/web/templates/default/apache.backend.erb
+++ b/cookbooks/web/templates/default/apache.backend.erb
@@ -55,6 +55,11 @@
   RemoteIPTrustedProxy 10.0.32.0/24
 
   #
+  # Pass authentication related headers to cgimap
+  #
+  CGIPassAuth On
+
+  #
   # Pass supported calls to cgimap
   #
   RewriteRule ^/api/0\.6/map$ fcgi://127.0.0.1:8000$0 [P]


### PR DESCRIPTION
The [Apache docs](https://httpd.apache.org/docs/2.4/mod/core.html#cgipassauth) say that this option is needed for `mod_proxy_fcgi` to pass "Authorization" to FCGI processes. CGImap needs to access this header in order to figure out if a request has a valid OAuth header.