### PR TITLE
Improve limits for tile speeds

### DIFF
--- a/cookbooks/tilecache/attributes/default.rb
+++ b/cookbooks/tilecache/attributes/default.rb
@@ -3,12 +3,12 @@ default[:tilecache][:tile_parent] = "parent.tile.openstreetmap.org"
 default[:tilecache][:tile_siblings] = []
 
 # Per IP bucket refill rate
-default[:tilecache][:ip_bucket_refill] = 4096
+default[:tilecache][:ip_bucket_refill] = 307200
 # Per IP bucket size
-default[:tilecache][:ip_bucket_size] = 67108864
+default[:tilecache][:ip_bucket_size] = 15728640
 # Per Class C refill rate
-default[:tilecache][:net_bucket_refill] = 8192
+default[:tilecache][:net_bucket_refill] = 39321600
 # Per Class C bucket size
-default[:tilecache][:net_bucket_size] = 134217728
+default[:tilecache][:net_bucket_size] = 2013265920
 
 default[:tilecache][:ssl][:certificate] = "tile.openstreetmap"

--- a/cookbooks/tilecache/templates/default/nginx_tile_ssl.conf.erb
+++ b/cookbooks/tilecache/templates/default/nginx_tile_ssl.conf.erb
@@ -37,6 +37,6 @@ server {
       proxy_set_header Connection "";
 
       # Slow traffic slightly
-      limit_rate 16384;
+      limit_rate 307200;
     }
 }


### PR DESCRIPTION
This pull request raises per-second limits for tile usages to comfortable values, and chops off bursts to disallow scraping.
