### PR TITLE
Output TagInfo <script> tag

### DIFF
--- a/cookbooks/mediawiki/templates/default/LocalSettings.php.erb
+++ b/cookbooks/mediawiki/templates/default/LocalSettings.php.erb
@@ -327,7 +327,7 @@ $wgReadOnly = "<%= @mediawiki[:site_readonly] %>";
 $wgHooks['BeforePageDisplay'][] ='outputTaginfoScriptTag';
 function outputTaginfoScriptTag( OutputPage &$out, Skin &$skin )
 {
-    $script = '<script type="text/javascript" src="http://taginfo.openstreetmap.org/js/taglists.js"></script>';
+    $script = '<script type="text/javascript" src="https://taginfo.openstreetmap.org/js/taglists.js"></script>';
     $out->addHeadItem("taginfo script", $script);
     return true;
 };

--- a/cookbooks/mediawiki/templates/default/LocalSettings.php.erb
+++ b/cookbooks/mediawiki/templates/default/LocalSettings.php.erb
@@ -322,3 +322,13 @@ $wgReadOnly = "<%= @mediawiki[:site_readonly] %>";
 <% Dir.glob("#{@directory}/LocalSettings.d/*.php") do |file| -%>
 <%= "require_once('#{file}');" %>
 <% end -%>
+
+# Output TagInfo script tag
+$wgHooks['BeforePageDisplay'][] ='outputTaginfoScriptTag';
+function outputTaginfoScriptTag( OutputPage &$out, Skin &$skin )
+{
+    $script = '<script type="text/javascript" src="http://taginfo.openstreetmap.org/js/taglists.js"></script>';
+    $out->addHeadItem("taginfo script", $script);
+    return true;
+};
+


### PR DESCRIPTION
For the "[taginfo taglists](https://wiki.openstreetmap.org/wiki/Taginfo/Taglists)" on the wiki. This thing is already in place and working, but so far we've kept a chunk of code on https://wiki.openstreetmap.org/wiki/MediaWiki:Common.js and @joto has been asking wiki admins (like me) to make little tweaks to it. He wanted to host it at his end instead (good idea?)

The approach for having mediawiki spit out a &lt;script> tag is [based on this answer](http://stackoverflow.com/a/26436873/338265). I have tested it. It works. But maybe you can see a better way.