### PR TITLE
Add lldpd support

### DIFF
--- a/cookbooks/hardware/recipes/default.rb
+++ b/cookbooks/hardware/recipes/default.rb
@@ -201,6 +201,13 @@ if node[:lsb][:release].to_f >= 12.10
   end
 end
 
+# Link Layer Discovery Protocol Daemon
+package "lldpd"
+service "lldpd" do
+  action [:start, :enable]
+  supports :status => true, :restart => true, :reload => true
+end
+
 tools_packages = []
 status_packages = {}
 


### PR DESCRIPTION
Add lldp daemon to get Link Layer Discovery Protocol (LLDP) announcements from switch and send LLDP announcements to switch.

lldpcli show neighbors # show switch port + details
lldpcli show chassis # show details sent to switch