### PR TITLE
Downloadable munin data

### DIFF
--- a/cookbooks/munin/files/default/rrddump.sh
+++ b/cookbooks/munin/files/default/rrddump.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+RRD_DIR=/var/lib/munin/openstreetmap
+DIR=`mktemp -d`
+NPROCS=8
+
+function cleanup {
+rm -rf "$DIR"
+}
+
+trap cleanup EXIT
+
+cd "$RRD_DIR"
+find -name "*.rrd" -print0 | xargs --null --max-procs=$NPROCS -I {} rrdtool dump {} "$DIR/{}.xml"
+
+cd "$DIR"
+find -name "*.xml" -print0 | tar zcf - --null -T -

--- a/cookbooks/munin/recipes/server.rb
+++ b/cookbooks/munin/recipes/server.rb
@@ -81,7 +81,13 @@ remote_directory "/srv/munin.openstreetmap.org" do
   files_owner "root"
   files_group "root"
   files_mode 0o644
-  purge true
+end
+
+# directory to put dumped files in
+directory "/srv/munin.openstreetmap.org/dumps" do
+  owner "www-data"
+  group "www-data"
+  mode 0o755
 end
 
 apache_site "munin.openstreetmap.org" do
@@ -90,6 +96,21 @@ end
 
 template "/etc/cron.daily/munin-backup" do
   source "backup.cron.erb"
+  owner "root"
+  group "root"
+  mode 0o755
+end
+
+# simple shell script to dump RRD data to a file
+cookbook_file "/usr/local/bin/rrddump" do
+  source "rrddump.sh"
+  owner "root"
+  group "root"
+  mode 0o755
+end
+
+template "/etc/cron.d/rrddump" do
+  source "rrddump.cron.erb"
   owner "root"
   group "root"
   mode 0o755

--- a/cookbooks/munin/templates/default/rrddump.cron.erb
+++ b/cookbooks/munin/templates/default/rrddump.cron.erb
@@ -1,0 +1,3 @@
+MAILTO=zerebubuth@gmail.com
+# do the dump in the early hours of the morning
+43 3 * * * www-data nice /usr/local/bin/rrddump > /srv/munin.openstreetmap.org/dumps/`date "+munin-data-%Y-%m-%d.tar.gz"`


### PR DESCRIPTION
Add simple script to dump munin data from RRD to XML and tar it up somewhere downloadable.

Alternatively, it could copy it back to the planet server and serve it from there. I figured it was a niche enough thing that it didn't really need that, but happy to implement if the general consensus is that it should be on planet.