### PR TITLE
Fixes to munin dump functionality

### DIFF
--- a/cookbooks/munin/files/default/rrddump.sh
+++ b/cookbooks/munin/files/default/rrddump.sh
@@ -2,16 +2,18 @@
 
 RRD_DIR=/var/lib/munin/openstreetmap
 DIR=`mktemp -d`
-NPROCS=8
 
 function cleanup {
-rm -rf "$DIR"
+  rm -rf "$DIR"
 }
 
 trap cleanup EXIT
 
 cd "$RRD_DIR"
-find -name "*.rrd" -print0 | xargs --null --max-procs=$NPROCS -I {} rrdtool dump {} "$DIR/{}.xml"
+for f in *.rrd; do
+  rrdtool dump "$f" "$DIR/${f}.xml"
+  touch -r "$f" "$DIR/${f}.xml"
+done
 
 cd "$DIR"
 find -name "*.xml" -print0 | tar zcf - --null -T -

--- a/cookbooks/munin/files/default/rrddump.sh
+++ b/cookbooks/munin/files/default/rrddump.sh
@@ -2,12 +2,17 @@
 
 RRD_DIR=/var/lib/munin/openstreetmap
 DIR=`mktemp -d`
+DUMP_DIR=/srv/munin.openstreetmap.org/dumps
+TARGET_TGZ=`date "+munin-data-%Y-%m-%d.tar.gz"`
+KEEP_OLD_COUNT=3
 
 function cleanup {
   rm -rf "$DIR"
 }
 
 trap cleanup EXIT
+
+set -e
 
 cd "$RRD_DIR"
 for f in *.rrd; do
@@ -16,4 +21,13 @@ for f in *.rrd; do
 done
 
 cd "$DIR"
-find -name "*.xml" -print0 | tar zcf - --null -T -
+find -name "*.xml" -print0 | tar zcf "dump.tar.gz" --null -T -
+
+# if we got here, then the file was created okay so we're okay to delete any
+# old files.
+find "${DUMP_DIR}" -name "munin-data-*.tar.gz" -print0 | \
+    sort -z -r | \
+    tail -z -n "+${KEEP_OLD_COUNT}" | \
+    xargs --null rm -f
+
+mv dump.tar.gz "${DUMP_DIR}/${TARGET_TGZ}"

--- a/cookbooks/munin/templates/default/rrddump.cron.erb
+++ b/cookbooks/munin/templates/default/rrddump.cron.erb
@@ -1,3 +1,3 @@
 MAILTO=zerebubuth@gmail.com
-# do the dump in the early hours of the morning and follow, if successful, by a cleanup of the old files. i don't think these are of any historical interest, so just keep three consecutive.
-43 3 * * * www-data nice /usr/local/bin/rrddump > /srv/munin.openstreetmap.org/dumps/`date "+munin-data-%Y-%m-%d.tar.gz"` && ls -1 /srv/munin.openstreetmap.org/dumps/munin-data-*.tar.gz | sort -r | tail -n +4 | xargs rm -f
+# do the dump & cleanup in the early hours of the morning
+43 3 * * * www-data nice /usr/local/bin/rrddump

--- a/cookbooks/munin/templates/default/rrddump.cron.erb
+++ b/cookbooks/munin/templates/default/rrddump.cron.erb
@@ -1,3 +1,3 @@
 MAILTO=zerebubuth@gmail.com
-# do the dump in the early hours of the morning
-43 3 * * * www-data nice /usr/local/bin/rrddump > /srv/munin.openstreetmap.org/dumps/`date "+munin-data-%Y-%m-%d.tar.gz"`
+# do the dump in the early hours of the morning and follow, if successful, by a cleanup of the old files. i don't think these are of any historical interest, so just keep three consecutive.
+43 3 * * * www-data nice /usr/local/bin/rrddump > /srv/munin.openstreetmap.org/dumps/`date "+munin-data-%Y-%m-%d.tar.gz"` && ls -1 /srv/munin.openstreetmap.org/dumps/munin-data-*.tar.gz | sort -r | tail -n +4 | xargs rm -f


### PR DESCRIPTION
* Touch XML files to reflect date of original RRD file.
* Don't run dump in parallel.
* Only keep latest 3 files, delete older ones.
