### PR TITLE
Specify database for osm2pgsql on rendering servers

### DIFF
--- a/cookbooks/tile/templates/default/replicate.erb
+++ b/cookbooks/tile/templates/default/replicate.erb
@@ -68,9 +68,9 @@ do
 
             # Apply the changes to the database
 <% if node[:tile][:node_file] -%>
-            osm2pgsql --slim --append --number-processes=1 --flat-nodes=<%= node[:tile][:node_file] %> ${file}
+            osm2pgsql --database gis --slim --append --number-processes=1 --flat-nodes=<%= node[:tile][:node_file] %> ${file}
 <% else -%>
-            osm2pgsql --slim --append --number-processes=1 ${file}
+            osm2pgsql --database gis --slim --append --number-processes=1 ${file}
 <% end -%>
 
             # No need to rollback now


### PR DESCRIPTION
#685 would change the default behavior of osm2pgsql. It may be a long time before this change makes it through osm2pgsql release, Debian packaging, Ubuntu packaging, and Ubuntu LTS release, but best practice is to specify the database name anyways.