### PR TITLE
Add Time to whitelist of classes to load for YAML.safe_load

### DIFF
--- a/cookbooks/planet/files/default/replication-bin/replicate-changesets
+++ b/cookbooks/planet/files/default/replication-bin/replicate-changesets
@@ -142,7 +142,7 @@ end
 class Replicator
   def initialize(config)
     @config = YAML.safe_load(File.read(config))
-    @state = YAML.safe_load(File.read(@config["state_file"]))
+    @state = YAML.safe_load(File.read(@config["state_file"]), [Time])
     @conn = PGconn.connect(@config["db"])
     # get current time from the database rather than the current system
     @now = @conn.exec("select now() as now").map { |row| Time.parse(row["now"]) }[0]


### PR DESCRIPTION
The update to ruby 2.3.1 pulls in a different version of the YAML / Psych code which doesn't allow the Time class to be loaded in `safe_load`, unlike the previous version. This change whitelists Time, and appears to solve the problem. Since `state.yaml` files are not loaded from the internet, and rarely hand-edited, then this seems like an okay thing to whitelist.

This fixes an error which was preventing changesets from being replicated since 2017-02-05 11:08.
