### PR TITLE
Delete the planet.db sqlite file on each run

### DIFF
--- a/cookbooks/blogs/templates/default/cron.erb
+++ b/cookbooks/blogs/templates/default/cron.erb
@@ -1,1 +1,1 @@
-*/30 * * * * blogs /usr/local/bin/pluto -c /srv/blogs.openstreetmap.org build -d /srv/blogs.openstreetmap.org -t osm -o /srv/blogs.openstreetmap.org/build /srv/blogs.openstreetmap.org/planet.yml
+*/30 * * * * blogs rm /srv/blogs.openstreetmap.org/planet.db && /usr/local/bin/pluto -c /srv/blogs.openstreetmap.org build -d /srv/blogs.openstreetmap.org -t osm -o /srv/blogs.openstreetmap.org/build /srv/blogs.openstreetmap.org/planet.yml


### PR DESCRIPTION
at least as a temporary solution to ensure spam gets blown away: https://github.com/gravitystorm/blogs.osm.org/issues/17

The sqlite file gets rebuilt completely on pluto build. Doing this on each iteration may not be what the pluto developer intended, but the result is the same ...but without the spam!