### PR TITLE
Use env to start bash

### DIFF
--- a/cookbooks/tile/templates/default/replicate.erb
+++ b/cookbooks/tile/templates/default/replicate.erb
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # DO NOT EDIT - This file is being maintained by Chef
 


### PR DESCRIPTION
Although it doesn't matter for OSMF servers, this file gets used as the basis for a lot of other scripts, and this is a more portable practice.