### PR TITLE
Use .osc.gz for diffs that tile replication fetches

### DIFF
--- a/cookbooks/tile/templates/default/expire-tiles.erb
+++ b/cookbooks/tile/templates/default/expire-tiles.erb
@@ -12,7 +12,7 @@ tile_dirs = [
 
 max_zoom = <%= node[:tile][:styles].collect { |n,d| d[:max_zoom] }.max %>
 
-Dir.glob("/var/lib/replicate/expire-queue/changes-*.osm.gz").each do |f|
+Dir.glob("/var/lib/replicate/expire-queue/changes-*.gz").each do |f|
    Expire::expire(f, 13, max_zoom, tile_dirs)
    File::unlink(f)
 end

--- a/cookbooks/tile/templates/default/replicate.erb
+++ b/cookbooks/tile/templates/default/replicate.erb
@@ -28,7 +28,7 @@ trap onexit EXIT
 while true
 do
     # Work out the name of the next file
-    file="changes-${sequenceNumber}.osm.gz"
+    file="changes-${sequenceNumber}.osc.gz"
 
     # Save state file so we can rollback if an error occurs
     cp state.txt state-prev.txt


### PR DESCRIPTION
This can matter on more recent versions of osm2pgsql where type detection is done by filename. The `find` cleanup line later on gets both osm and osc files, so no changes are needed there.