### PR TITLE
Change the title to not mention 'wiki'

### DIFF
--- a/cookbooks/foundation/recipes/wiki.rb
+++ b/cookbooks/foundation/recipes/wiki.rb
@@ -24,7 +24,7 @@ passwords = data_bag_item("foundation", "passwords")
 mediawiki_site "wiki.osmfoundation.org" do
   aliases ["www.osmfoundation.org", "osmfoundation.org",
            "foundation.openstreetmap.org", "foundation.osm.org"]
-  sitename "OpenStreetMap Foundation Wiki"
+  sitename "OpenStreetMap Foundation"
   directory "/srv/wiki.osmfoundation.org"
   ssl_enabled true
   database_name "osmf-wiki"


### PR DESCRIPTION
This feeds into $wgSitename which feeds into various places https://www.mediawiki.org/wiki/Manual:$wgSitename most obviously the HTML &lt;title> tag.

@simonpoole was asking for the word 'wiki' to be removed from the HTML title, which I agree with. In fact from a site visitor's point of view, the wiki-ness of the site would ideally be largely hidden. This is one step to doing so (the other key one would be rewriting URLs)

One concern with this change would be that it might cause a rename of the "project" namespace, but from what I can tell this has taken the name "OpenStreetMap" anyway for some reason.