### PR TITLE
Reduce WAL archive length.

### DIFF
--- a/cookbooks/db/templates/default/cron.erb
+++ b/cookbooks/db/templates/default/cron.erb
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-# Cleanup archive directory
-find -L /store/postgresql/archive -mtime +40 -print0 | xargs -0r rm
+# Cleanup archive directory - keep 3 weeks of WALs
+find -L /store/postgresql/archive -mtime +21 -print0 | xargs -0r rm


### PR DESCRIPTION
Was 40 days, this reduces it to 21 days. That should roughly halve the amount of disk space needed to store all the WALs, at the cost that it's more difficult to recover a replica which has been out of sync for between 22 and 40 days.