### PR TITLE
Make serverinfo available on hardware.osm.org

### DIFF
--- a/cookbooks/serverinfo/recipes/default.rb
+++ b/cookbooks/serverinfo/recipes/default.rb
@@ -67,11 +67,12 @@ execute "/srv/hardware.openstreetmap.org" do
 end
 
 ssl_certificate "hardware.openstreetmap.org" do
-  domains "hardware.openstreetmap.org"
+  domains ["hardware.openstreetmap.org", "hardware.osm.org"]
   notifies :reload, "service[apache2]"
 end
 
 apache_site "hardware.openstreetmap.org" do
   template "apache.erb"
   directory "/srv/hardware.openstreetmap.org/_site"
+  variables :aliases => "hardware.osm.org"
 end

--- a/cookbooks/serverinfo/templates/default/apache.erb
+++ b/cookbooks/serverinfo/templates/default/apache.erb
@@ -2,6 +2,7 @@
 
 <VirtualHost *:80>
    ServerName <%= @name %>
+   ServerAlias <%= @aliases %>
    ServerAdmin webmaster@openstreetmap.org
 
    CustomLog /var/log/apache2/<%= @name %>-access.log combined
@@ -13,6 +14,7 @@
 
 <VirtualHost *:443>
    ServerName <%= @name %>
+   ServerAlias <%= @aliases %>
    ServerAdmin webmaster@openstreetmap.org
 
    CustomLog /var/log/apache2/<%= @name %>-access.log combined


### PR DESCRIPTION
http://hardware.osm.org currently shows the default Ubuntu apache webpage.
With this change this domains is bound to http://hardware.openstreetmap.org as well as hardware.osm.org and SSL Certificates would be created for both.

Delete this PR if this behaviour is intended.