### PR TITLE
Add mcelog daemon

### DIFF
--- a/cookbooks/hardware/recipes/default.rb
+++ b/cookbooks/hardware/recipes/default.rb
@@ -200,6 +200,13 @@ service "lldpd" do
   supports :status => true, :restart => true, :reload => true
 end
 
+# mcelog Daemon to log / alert on machine check events
+package "mcelog"
+service "mcelog" do
+  action [:start, :enable]
+  supports :status => true, :restart => true, :reload => false
+end
+
 tools_packages = []
 status_packages = {}
 


### PR DESCRIPTION
Add the mcelog daemon to log machine check events.

The Corrected Error (CE) ECC events are useful. The daemon by default attempts to "Offline" memory which has repeated CE errors.

We should likely add some custom alerting via `/etc/mcelog/[error type]-trigger.local` scripts 