### PR TITLE
Use Foodcritic 12.2.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
     ffi (1.9.18)
     ffi-yajl (2.3.1)
       libyajl2 (~> 1.2)
-    foodcritic (12.2.0)
+    foodcritic (12.2.1)
       cucumber-core (>= 1.3)
       erubis
       ffi-yajl (~> 2.0)
@@ -143,4 +143,4 @@ DEPENDENCIES
   test-kitchen
 
 BUNDLED WITH
-   1.15.4
+   1.16.0


### PR DESCRIPTION
12.2.0 has a pretty nasty regression where it alerted on any resource
that had an action named :create, which was not the intention

Signed-off-by: Tim Smith <tsmith@chef.io>