### PR TITLE
Use multipackage installs throughout

### DIFF
--- a/cookbooks/accounts/recipes/default.rb
+++ b/cookbooks/accounts/recipes/default.rb
@@ -17,9 +17,7 @@
 # limitations under the License.
 #
 
-package "zsh" do
-  action :install
-end
+package "zsh"
 
 administrators = []
 

--- a/cookbooks/apache/recipes/default.rb
+++ b/cookbooks/apache/recipes/default.rb
@@ -19,8 +19,10 @@
 
 include_recipe "ssl"
 
-package "apache2"
-package "libwww-perl"
+package %w[
+  apache2
+  libwww-perl
+]
 
 %w[event itk prefork worker].each do |mpm|
   if mpm == node[:apache][:mpm]

--- a/cookbooks/apt/recipes/default.rb
+++ b/cookbooks/apt/recipes/default.rb
@@ -17,9 +17,11 @@
 # limitations under the License.
 #
 
-package "apt"
-package "gnupg-curl"
-package "update-notifier-common"
+package %w[
+  apt
+  gnupg-curl
+  update-notifier-common
+]
 
 file "/etc/motd.tail" do
   action :delete

--- a/cookbooks/backup/recipes/default.rb
+++ b/cookbooks/backup/recipes/default.rb
@@ -17,8 +17,10 @@
 # limitations under the License.
 #
 
-package "perl"
-package "libdate-calc-perl"
+package %w[
+  perl
+  libdate-calc-perl
+]
 
 directory "/store/backup" do
   owner "osmbackup"

--- a/cookbooks/blogs/recipes/default.rb
+++ b/cookbooks/blogs/recipes/default.rb
@@ -20,11 +20,12 @@
 include_recipe "apache"
 include_recipe "git"
 
-package "ruby"
-package "ruby-dev"
-package "make"
-package "gcc"
-package "libsqlite3-dev"
+package %w[
+  ruby
+  ruby-dev
+  make gcc
+  libsqlite3-dev
+]
 
 gem_package "bundler"
 

--- a/cookbooks/clamav/recipes/default.rb
+++ b/cookbooks/clamav/recipes/default.rb
@@ -17,9 +17,11 @@
 # limitations under the License.
 #
 
-package "clamav-daemon"
-package "clamav-freshclam"
-package "clamav-unofficial-sigs"
+package %w[
+  clamav-daemon
+  clamav-freshclam
+  clamav-unofficial-sigs
+]
 
 template "/etc/clamav-unofficial-sigs.conf.d/50-chef.conf" do
   source "clamav-unofficial-sigs.conf.erb"

--- a/cookbooks/dev/recipes/default.rb
+++ b/cookbooks/dev/recipes/default.rb
@@ -28,30 +28,36 @@ include_recipe "nodejs"
 include_recipe "postgresql"
 include_recipe "python"
 
-package "php"
-package "php-cgi"
-package "php-cli"
-package "php-curl"
-package "php-db"
-package "php-fpm"
-package "php-imagick"
-package "php-mcrypt"
-package "php-mysql"
-package "php-pear"
-package "php-pgsql"
-package "php-sqlite3"
+package %w[
+  php
+  php-cgi
+  php-cli
+  php-curl
+  php-db
+  php-fpm
+  php-imagick
+  php-mcrypt
+  php-mysql
+  php-pear
+  php-pgsql
+  php-sqlite3
+]
 
-package "pngcrush"
-package "pngquant"
+package %w[
+  pngcrush
+  pngquant
+]
 
-package "python"
-package "python-argparse"
-package "python-beautifulsoup"
-package "python-cheetah"
-package "python-dateutil"
-package "python-magic"
-package "python-psycopg2"
-package "python-gdal"
+package %w[
+  python
+  python-argparse
+  python-beautifulsoup
+  python-cheetah
+  python-dateutil
+  python-magic
+  python-psycopg2
+  python-gdal
+]
 
 nodejs_package "svgo"
 

--- a/cookbooks/dns/recipes/default.rb
+++ b/cookbooks/dns/recipes/default.rb
@@ -22,14 +22,15 @@ include_recipe "apache"
 
 passwords = data_bag_item("dns", "passwords")
 
-package "make"
-
-package "perl"
-package "libxml-treebuilder-perl"
-package "libxml-writer-perl"
-package "libyaml-perl"
-package "libwww-perl"
-package "libjson-xs-perl"
+package %w[
+  make
+  perl
+  libxml-treebuilder-perl
+  libxml-writer-perl
+  libyaml-perl
+  libwww-perl
+  libjson-xs-perl
+]
 
 directory "/srv/dns.openstreetmap.org" do
   owner "root"

--- a/cookbooks/donate/recipes/default.rb
+++ b/cookbooks/donate/recipes/default.rb
@@ -21,11 +21,13 @@ include_recipe "apache"
 include_recipe "mysql"
 include_recipe "git"
 
-package "php"
-package "php-cli"
-package "php-curl"
-package "php-mysql"
-package "php-gd"
+package %w[
+  php
+  php-cli
+  php-curl
+  php-mysql
+  php-gd
+]
 
 apache_module "php7.0"
 

--- a/cookbooks/elasticsearch/recipes/default.rb
+++ b/cookbooks/elasticsearch/recipes/default.rb
@@ -17,8 +17,10 @@
 # limitations under the License.
 #
 
-package "default-jre-headless"
-package "elasticsearch"
+package %w[
+  default-jre-headless
+  elasticsearch
+]
 
 template "/etc/elasticsearch/elasticsearch.yml" do
   source "elasticsearch.yml.erb"

--- a/cookbooks/exim/recipes/default.rb
+++ b/cookbooks/exim/recipes/default.rb
@@ -19,9 +19,11 @@
 
 include_recipe "networking"
 
-package "exim4"
-package "openssl"
-package "ssl-cert"
+package %w[
+  exim4
+  openssl
+  ssl-cert
+]
 
 package "exim4-daemon-heavy" if File.exist?("/var/run/clamav/clamd.ctl")
 

--- a/cookbooks/forum/recipes/default.rb
+++ b/cookbooks/forum/recipes/default.rb
@@ -22,11 +22,13 @@ include_recipe "mysql"
 
 passwords = data_bag_item("forum", "passwords")
 
-package "php"
-package "php-cli"
-package "php-mysql"
-package "php-xml"
-package "php-apcu"
+package %w[
+  php
+  php-cli
+  php-mysql
+  php-xml
+  php-apcu
+]
 
 apache_module "php7.0"
 apache_module "rewrite"

--- a/cookbooks/foundation/recipes/owg.rb
+++ b/cookbooks/foundation/recipes/owg.rb
@@ -20,8 +20,10 @@
 include_recipe "apache"
 include_recipe "git"
 
-package "ruby"
-package "ruby-dev"
+package %w[
+  ruby
+  ruby-dev
+]
 
 gem_package "bundler"
 

--- a/cookbooks/geodns/recipes/default.rb
+++ b/cookbooks/geodns/recipes/default.rb
@@ -17,9 +17,10 @@
 # limitations under the License.
 #
 
-package "geoip-database-contrib"
-
-package "gdnsd"
+package %w[
+  geoip-database-contrib
+  gdnsd
+]
 
 service "gdnsd" do
   action [:enable, :start]

--- a/cookbooks/gps-tile/recipes/default.rb
+++ b/cookbooks/gps-tile/recipes/default.rb
@@ -19,16 +19,18 @@
 
 include_recipe "apache"
 
-package "make"
-package "build-essential"
-package "pkg-config"
-package "zlib1g-dev"
-package "libbz2-dev"
-package "libarchive-dev"
-package "libexpat1-dev"
-package "libpng-dev"
-package "pngquant"
-package "libcache-memcached-perl"
+package %w[
+  make
+  build-essential
+  pkg-config
+  zlib1g-dev
+  libbz2-dev
+  libarchive-dev
+  libexpat1-dev
+  libpng-dev
+  pngquant
+  libcache-memcached-perl
+]
 
 directory "/srv/gps-tile.openstreetmap.org" do
   owner "gpstile"

--- a/cookbooks/imagery/recipes/default.rb
+++ b/cookbooks/imagery/recipes/default.rb
@@ -21,24 +21,32 @@ include_recipe "nginx"
 include_recipe "git"
 
 # Imagery gdal Requirements
-package "gdal-bin"
-package "python-gdal"
+package %w[
+  gdal-bin
+  python-gdal
+]
 
 # Imagery MapServer + Mapcache Requirements
-package "cgi-mapserver"
-package "mapcache-cgi"
-package "mapcache-tools"
+package %w[
+  cgi-mapserver
+  mapcache-cgi
+  mapcache-tools
+]
 
 # Mapserver via Nginx requires as fastcgi spawner
-package "spawn-fcgi"
-package "multiwatch"
+package %w[
+  spawn-fcgi
+  multiwatch
+]
 
 # Imagery processing Requirements
 package "imagemagick"
 
 # Imagery misc compression
-package "xz-utils"
-package "unzip"
+package %w[
+  xz-utils
+  unzip
+]
 
 directory "/srv/imagery/mapserver" do
   owner "root"

--- a/cookbooks/letsencrypt/recipes/default.rb
+++ b/cookbooks/letsencrypt/recipes/default.rb
@@ -21,8 +21,10 @@ include_recipe "apache"
 
 keys = data_bag_item("chef", "keys")
 
-package "certbot"
-package "ruby"
+package %w[
+  certbot
+  ruby
+]
 
 directory "/etc/letsencrypt" do
   owner "letsencrypt"

--- a/cookbooks/logstash/recipes/default.rb
+++ b/cookbooks/logstash/recipes/default.rb
@@ -21,8 +21,10 @@ include_recipe "networking"
 
 keys = data_bag_item("logstash", "keys")
 
-package "default-jre-headless"
-package "logstash"
+package %w[
+  default-jre-headless
+  logstash
+]
 
 cookbook_file "/var/lib/logstash/lumberjack.crt" do
   source "lumberjack.crt"

--- a/cookbooks/mediawiki/recipes/default.rb
+++ b/cookbooks/mediawiki/recipes/default.rb
@@ -23,33 +23,43 @@ include_recipe "mysql"
 include_recipe "git"
 
 # Mediawiki Base Requirements
-package "php"
-package "php-cli"
-package "php-curl"
-package "php-gd"
-package "php-intl"
-package "php-mbstring"
-package "php-mysql"
-package "php-xml"
+package %w[
+  php
+  php-cli
+  php-curl
+  php-gd
+  php-intl
+  php-mbstring
+  php-mysql
+  php-xml
+]
 
 # Mediawiki enhanced difference engine
 package "php-wikidiff2"
 
 # Mediawiki Image + SVG support
-package "imagemagick"
-package "librsvg2-bin"
+package %w[
+  imagemagick
+  librsvg2-bin
+]
 
 # Mediawiki PDF support via Extension:PdfHandler
-package "ghostscript"
-package "poppler-utils"
+package %w[
+  ghostscript
+  poppler-utils
+]
 
 # Mediawiki backup
-package "xz-utils"
-package "liblz4-tool"
+package %w[
+  xz-utils
+  liblz4-tool
+]
 
 # Mediawiki packages for VisualEditor support
-package "curl"
-package "parsoid"
+package %w[
+  curl
+  parsoid
+]
 
 # Mediawiki packages for SyntaxHighight support
 package "python-pygments"

--- a/cookbooks/ntp/recipes/default.rb
+++ b/cookbooks/ntp/recipes/default.rb
@@ -19,9 +19,11 @@
 
 require "socket"
 
-package "ntp"
-package "ntpdate"
-package "tzdata"
+package %w[
+  ntp
+  ntpdate
+  tzdata
+]
 
 execute "dpkg-reconfigure-tzdata" do
   action :nothing

--- a/cookbooks/sysctl/recipes/default.rb
+++ b/cookbooks/sysctl/recipes/default.rb
@@ -17,9 +17,7 @@
 # limitations under the License.
 #
 
-package "procps" do
-  action :install
-end
+package "procps"
 
 directory "/etc/sysctl.d" do
   owner "root"

--- a/cookbooks/taginfo/recipes/default.rb
+++ b/cookbooks/taginfo/recipes/default.rb
@@ -23,23 +23,27 @@ include_recipe "apache"
 include_recipe "passenger"
 include_recipe "git"
 
-package "libsqlite3-dev"
-package "zlib1g-dev"
-package "libbz2-dev"
-package "libboost-dev"
-package "libexpat1-dev"
-package "libsparsehash-dev"
-package "libgd2-xpm-dev"
-package "libicu-dev"
-package "libboost-program-options-dev"
-package "cmake"
-package "make"
-package "g++"
+package %w[
+  libsqlite3-dev
+  zlib1g-dev
+  libbz2-dev
+  libboost-dev
+  libexpat1-dev
+  libsparsehash-dev
+  libgd2-xpm-dev
+  libicu-dev
+  libboost-program-options-dev
+  cmake
+  make
+  g++
+]
 
-package "sqlite3"
-package "osmosis"
-package "curl"
-package "pbzip2"
+package %w[
+  sqlite3
+  osmosis
+  curl
+  pbzip2
+]
 
 ruby_version = node[:passenger][:ruby_version]
 

--- a/cookbooks/tile/recipes/default.rb
+++ b/cookbooks/tile/recipes/default.rb
@@ -118,17 +118,21 @@ template "/srv/tile.openstreetmap.org/html/index.html" do
   mode 0o644
 end
 
-package "python-cairo"
-package "python-mapnik"
-package "python-setuptools"
+package %w[
+  python-cairo
+  python-mapnik
+  python-setuptools
+]
 
 python_package "pyotp"
 
-package "fonts-noto-cjk"
-package "fonts-noto-hinted"
-package "fonts-noto-unhinted"
-package "fonts-hanazono"
-package "ttf-unifont"
+package %w[
+  fonts-noto-cjk
+  fonts-noto-hinted
+  fonts-noto-unhinted
+  fonts-hanazono
+  ttf-unifont
+]
 
 ["NotoSansArabicUI-Regular.ttf", "NotoSansArabicUI-Bold.ttf"].each do |font|
   remote_file "/usr/share/fonts/truetype/noto/#{font}" do
@@ -421,14 +425,20 @@ directory "/var/log/tile" do
   mode 0o755
 end
 
-package "osm2pgsql"
-package "osmosis"
+package %w[
+  osm2pgsql
+  osmosis
+]
 
-package "ruby"
-package "ruby-dev"
+package %w[
+  ruby
+  ruby-dev
+]
 
-package "libproj-dev"
-package "libxml2-dev"
+package %w[
+  libproj-dev
+  libxml2-dev
+]
 
 gem_package "proj4rb"
 gem_package "libxml-ruby"

--- a/cookbooks/tilecache/recipes/default.rb
+++ b/cookbooks/tilecache/recipes/default.rb
@@ -27,8 +27,10 @@ package "apache2" do
   action :remove
 end
 
-package "xz-utils"
-package "openssl"
+package %w[
+  xz-utils
+  openssl
+]
 
 # oathtool for QoS token
 package "oathtool"

--- a/cookbooks/tilelog/recipes/default.rb
+++ b/cookbooks/tilelog/recipes/default.rb
@@ -19,13 +19,15 @@
 
 include_recipe "tools"
 
-package "gcc"
-package "make"
-package "autoconf"
-package "automake"
-package "libboost-filesystem-dev"
-package "libboost-system-dev"
-package "libboost-program-options-dev"
+package %w[
+  gcc
+  make
+  autoconf
+  automake
+  libboost-filesystem-dev
+  libboost-system-dev
+  libboost-program-options-dev
+]
 
 tilelog_source_directory = node[:tilelog][:source_directory]
 tilelog_input_directory = node[:tilelog][:input_directory]

--- a/cookbooks/tools/recipes/default.rb
+++ b/cookbooks/tools/recipes/default.rb
@@ -17,24 +17,26 @@
 # limitations under the License.
 #
 
-package "bash-completion"
-package "dmidecode"
-package "ethtool"
-package "lsof"
-package "lsscsi"
-package "pciutils"
-package "screen"
-package "smartmontools"
-package "strace"
-package "sysstat"
-package "tcpdump"
-package "usbutils"
-package "numactl"
-package "xfsprogs"
-package "sysv-rc-conf"
-package "iotop"
-package "lvm2"
-package "rsyslog"
+package %w[
+  bash-completion
+  dmidecode
+  ethtool
+  lsof
+  lsscsi
+  pciutils
+  screen
+  smartmontools
+  strace
+  sysstat
+  tcpdump
+  usbutils
+  numactl
+  xfsprogs
+  sysv-rc-conf
+  iotop
+  lvm2
+  rsyslog
+]
 
 service "rsyslog" do
   action [:enable, :start]

--- a/cookbooks/trac/recipes/default.rb
+++ b/cookbooks/trac/recipes/default.rb
@@ -19,9 +19,11 @@
 
 include_recipe "apache"
 
-package "trac"
-package "trac-git"
-package "ruby"
+package %w[
+  trac
+  trac-git
+  ruby
+]
 
 site_name = "trac.openstreetmap.org"
 site_directory = "/srv/#{site_name}"

--- a/cookbooks/web/recipes/gpx.rb
+++ b/cookbooks/web/recipes/gpx.rb
@@ -21,16 +21,18 @@ include_recipe "web::base"
 
 db_passwords = data_bag_item("db", "passwords")
 
-package "gcc"
-package "make"
-package "pkg-config"
-package "libarchive-dev"
-package "libbz2-dev"
-package "libexpat1-dev"
-package "libgd2-noxpm-dev"
-package "libmemcached-dev"
-package "libpq-dev"
-package "zlib1g-dev"
+package %w[
+  gcc
+  make
+  pkg-config
+  libarchive-dev
+  libbz2-dev
+  libexpat1-dev
+  libgd2-noxpm-dev
+  libmemcached-dev
+  libpq-dev
+  zlib1g-dev
+]
 
 gpx_directory = "#{node[:web][:base_directory]}/gpx-import"
 pid_directory = node[:web][:pid_directory]

--- a/cookbooks/wordpress/recipes/default.rb
+++ b/cookbooks/wordpress/recipes/default.rb
@@ -20,10 +20,11 @@
 include_recipe "apache"
 include_recipe "mysql"
 
-package "subversion"
-
-package "php"
-package "php-mysql"
+package %w[
+  subversion
+  php
+  php-mysql
+]
 
 apache_module "php7.0"
 apache_module "rewrite"

--- a/cookbooks/yournavigation/recipes/default.rb
+++ b/cookbooks/yournavigation/recipes/default.rb
@@ -19,27 +19,30 @@
 
 include_recipe "apache"
 
-package "php"
-package "php-cli"
-package "php-apcu"
+package %w[
+  php
+  php-cli
+  php-apcu
+]
 
 # Required for osmosis
 package "default-jre-headless"
 
 # Required for building gosmore
-package "build-essential"
-package "libxml2-dev"
-package "libgtk2.0-dev"
-package "subversion"
-package "libcurl4-gnutls-dev"
-package "libgps-dev"
-package "libcurl3"
-package "buffer"
-package "git"
-package "cmake"
-package "libqt4-dev"
-package "qt4-dev-tools"
-package "qt4-linguist-tools"
-package "libicu-dev"
+package %w[
+  build-essential
+  libxml2-dev
+  libgtk2.0-dev
+  subversion
+  libcurl4-gnutls-dev
+  libgps-dev libcurl3
+  buffer
+  git
+  cmake
+  libqt4-dev
+  qt4-dev-tools
+  qt4-linguist-tools
+  libicu-dev
+]
 
 apache_module "php7.0"


### PR DESCRIPTION
In Chef 12.1 we introduced multipackage installs. Instead of shelling out to dpkg for each package to determine what we should do we gather the information we need and check each package in the array. It's faster and it takes less memory. It's especially useful after the first run when nothing actually changes. Far fewer resources consumed. I noticed you arranged the packages so I tried to keep them to that same arrangement and I used multiline arrays since they make the diffs nicer in the future as you add / remove packages. This isn't necessary for Chef 13, but it's best practice.

Signed-off-by: Tim Smith <tsmith@chef.io>