### PR TITLE
add skin to OSMF mediawiki instance

### DIFF
--- a/cookbooks/foundation/recipes/wiki.rb
+++ b/cookbooks/foundation/recipes/wiki.rb
@@ -48,6 +48,13 @@ mediawiki_skin "osmf" do
   revision "master"
 end
 
+mediawiki_skin "OSMFoundation" do
+  site "wiki.osmfoundation.org"
+  repository "git://github.com/osmfoundation/osmf-mediawiki-skin.git"
+  revision "master"
+  legacy False
+end
+
 cookbook_file "/srv/wiki.osmfoundation.org/Wiki.png" do
   owner node[:mediawiki][:user]
   group node[:mediawiki][:group]


### PR DESCRIPTION
Trying to refresh the mediawiki skin on the OSMF mediawiki instance. The repository for the skin lives at https://github.com/osmfoundation/osmf-mediawiki-skin. This PR is meant to enable individual users on that instance to be able to test the skin without making it the default.

Please note that my Ruby knowledge is only basic and my Chef knowledge is nearly nonexistent.