### PR TITLE
Use https URL for html base tag for nominatim.openstreetmap.org.

### DIFF
--- a/cookbooks/nominatim/templates/default/settings.erb
+++ b/cookbooks/nominatim/templates/default/settings.erb
@@ -2,10 +2,7 @@
 # DO NOT EDIT - This file is being maintained by Chef
 
 @define('CONST_Database_DSN', 'pgsql://@/<%= @dbname %>');
-if (isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']))
-    @define('CONST_Website_BaseURL', 'https://<%= @base_url %>/');
-else
-    @define('CONST_Website_BaseURL', 'http://<%= @base_url %>/');
+@define('CONST_Website_BaseURL', 'https://<%= @base_url %>/');
 
 @define('CONST_Pyosmium_Binary', '/usr/local/bin/pyosmium-get-changes');
 


### PR DESCRIPTION
The <base> tag on nominatim.openstreetmap.org currently keeps the protocol. This changes it to always direct browsers to the https version, encouraging https without the breakage risks that a redirect would bring.
