### PR TITLE
Run old planet file cleanup on first Monday of the month.

### DIFF
--- a/cookbooks/planet/templates/default/old-planet-file-cleanup.cron.erb
+++ b/cookbooks/planet/templates/default/old-planet-file-cleanup.cron.erb
@@ -1,4 +1,4 @@
 # DO NOT EDIT - This file is being maintained by Chef
 MAILTO=zerebubuth@gmail.com
 # run this on the first monday of the month at 3:44am
-44 3 1-7 * mon www-data /usr/local/bin/old-planet-file-cleanup --dry-run --debug
+44 3 1-7 * * www-data test $(date +\%u) -eq 1 && /usr/local/bin/old-planet-file-cleanup --dry-run --debug


### PR DESCRIPTION
Not every Monday and additionally the 1st through 7th, as the previous cron configuration actually meant. Turns out the command runs when either the day of week matches _or_ the day of month matches, unlike all the other rules.

This fixes it to only run on the 1st Monday of the month by filtering the invocations, as suggested by the example in the `crontab(5)` man page.