### PR TITLE
Set autovacuum scale factors for tile servers

### DIFF
--- a/roles/tile.rb
+++ b/roles/tile.rb
@@ -43,7 +43,9 @@ default_attributes(
         :checkpoint_segments => "60",
         :max_wal_size => "2880MB",
         :random_page_cost => "1.1",
-        :track_activity_query_size => "16384"
+        :track_activity_query_size => "16384",
+        :autovacuum_vacuum_scale_factor => "0.05",
+        :autovacuum_analyze_scale_factor => "0.02"
       }
     }
   },


### PR DESCRIPTION
Reducing these factors helps make sure autovacuum runs often enough and keeps bloat down.

I haven't tested this code change, but have tested these values on render servers and find they work far better than the defaults.

This change will **not** remove existing bloat but cap it's future growth.