### PR TITLE
Bump planet-dump-ng version to v1.1.6.

### DIFF
--- a/cookbooks/planet/recipes/dump.rb
+++ b/cookbooks/planet/recipes/dump.rb
@@ -55,7 +55,7 @@ end
 git "/opt/planet-dump-ng" do
   action :sync
   repository "git://github.com/zerebubuth/planet-dump-ng.git"
-  revision "v1.1.4"
+  revision "v1.1.6"
   user "root"
   group "root"
 end


### PR DESCRIPTION
Version 1.1.6 includes a [fix for the table header parser](https://github.com/zerebubuth/planet-dump-ng/commit/89e8567a025d4bd88cfeaa62ac962721c6b81fb4) to allow explicit public schemas, which started getting added to the dumps as part of the upstream [PostgreSQL fix for CVE-2018-1058](https://wiki.postgresql.org/wiki/A_Guide_to_CVE-2018-1058:_Protect_Your_Search_Path).