### PR TITLE
Enable old planet file cleanup

### DIFF
--- a/cookbooks/planet/templates/default/old-planet-file-cleanup.cron.erb
+++ b/cookbooks/planet/templates/default/old-planet-file-cleanup.cron.erb
@@ -1,4 +1,4 @@
 # DO NOT EDIT - This file is being maintained by Chef
 MAILTO=zerebubuth@gmail.com
 # run this on the first monday of the month at 3:44am
-44 3 1-7 * * www-data test $(date +\%u) -eq 1 && /usr/local/bin/old-planet-file-cleanup --dry-run --debug
+44 3 1-7 * * www-data test $(date +\%u) -eq 1 && /usr/local/bin/old-planet-file-cleanup --debug

--- a/cookbooks/planet/templates/default/old-planet-file-cleanup.erb
+++ b/cookbooks/planet/templates/default/old-planet-file-cleanup.erb
@@ -88,7 +88,7 @@ to_delete += deletions(
    "planet-%y%m%d.osm.bz2.md5"])
 
 to_delete += deletions(
-  "#{xml_history_directory}/20??/planet-??????.osm.bz2",
+  "#{xml_history_directory}/20??/history-??????.osm.bz2",
   /history-([0-9]{6}).osm.bz2/,
   today,
   ["history-%y%m%d.osm.bz2",


### PR DESCRIPTION
Enable the old planet file cleanup on ironbelly and grisu by removing the `--dry-run` flag from the script.

It has been running as expected, except for a typo which meant it wasn't cleaning up old XML full history planet files. That's fixed below.

If you're happy with this, and we merge it, then I'll run it by hand once and again in `--dry-run`, just to make doubly sure that it's doing what it's supposed to in-situ. (I already tested this locally, but always worth being careful!)
