### PR TITLE
Redirect tilecache http requests to https

### DIFF
--- a/cookbooks/squid/templates/default/squid.conf.erb
+++ b/cookbooks/squid/templates/default/squid.conf.erb
@@ -12,7 +12,7 @@ icp_port 3130
 log_icp_queries off
 
 #FIXME - configurable
-http_port 80 accel defaultsite=tile.openstreetmap.org tcpkeepalive=60,10,6 http11
+http_port 127.0.0.1:8080 accel defaultsite=tile.openstreetmap.org tcpkeepalive=60,10,6 http11
 
 cache_effective_user proxy
 cache_effective_group proxy

--- a/cookbooks/tilecache/templates/default/nginx_tile.conf.erb
+++ b/cookbooks/tilecache/templates/default/nginx_tile.conf.erb
@@ -1,7 +1,7 @@
 # DO NOT EDIT - This file is being maintained by Chef
 
 upstream tile_cache_backend {
-    server 127.0.0.1;
+    server 127.0.0.1:8080;
     <% @caches.each do |cache| -%>
     <% if cache[:hostname] != node[:hostname] -%>
     #Server <%= cache[:hostname] %>
@@ -95,4 +95,12 @@ server {
       proxy_set_header Cache-Control $limit_http_cache_control;
       proxy_set_header Pragma $limit_http_pragma;
     }
+}
+
+# Convert all http requests to https
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    server_name _;
+    return 301 https://$host$request_uri;
 }


### PR DESCRIPTION
* Make squid listen on 127.0.0.1:8080
* Point nginx to 127.0.0.1:8080
* Make nginx listen on port 80 and redirect http requests there to https

Closes https://github.com/openstreetmap/operations/issues/117 and https://github.com/openstreetmap/operations/issues/190.