### PR TITLE
Nominatim: search_country table got removed in April

### DIFF
--- a/cookbooks/nominatim/templates/default/vacuum-db-nominatim.erb
+++ b/cookbooks/nominatim/templates/default/vacuum-db-nominatim.erb
@@ -6,7 +6,6 @@
 # Vaccum all tables with indices on integer arrays.
 # Agressive vacuuming seems to help against index bloat.
 psql -q -d <%= @db %> -c 'VACUUM ANALYSE search_name'
-psql -q -d <%= @db %> -c 'VACUUM ANALYSE search_name_country'
 
 for i in `seq 0 250`; do
   psql -q -d <%= @db %> -c "VACUUM ANALYSE search_name_${i}"


### PR DESCRIPTION
The `search_name_country` table got removed in https://github.com/openstreetmap/Nominatim/commit/53c526c01

cc @lonvia 