### PR TITLE
Add #osm-cwg to irc.osm.org drop-down

### DIFF
--- a/cookbooks/cgiirc/templates/default/cgiirc.config.erb
+++ b/cookbooks/cgiirc/templates/default/cgiirc.config.erb
@@ -8,7 +8,7 @@
 # Configure defaults
 default_server = irc.oftc.net
 default_port = 6667
-default_channel = #osm,#osm-dev,#osm-ewg,#osm-ar,#osm-asia,#osm-au,#osm-br,#osm-bw,#osm-by,#osm-ca,#osm-ch,#osm-cz,#osm-de,#osm-dk,#osm-es,#osm-fi,#osm-fr,#osm-gb,#osm-gr,#osm-gsoc,#osm-ht,#osm-ie,#osm-it,#osm-ke,#osm-latam,#osm-local,#osm-lv,#osm-nl,#osm-no,#osm-nominatim,#osm-pl,#osm-pt,#osm-ru,#osm.se,#osm-strategic,#osm-ua,#osm-us,#osm-za,#osm-zh,#osmf-gm,#osrm,#openrailwaymap,#hot
+default_channel = #osm,#osm-dev,#osm-ewg,#osm-cwg,#osm-ar,#osm-asia,#osm-au,#osm-br,#osm-bw,#osm-by,#osm-ca,#osm-ch,#osm-cz,#osm-de,#osm-dk,#osm-es,#osm-fi,#osm-fr,#osm-gb,#osm-gr,#osm-gsoc,#osm-ht,#osm-ie,#osm-it,#osm-ke,#osm-latam,#osm-local,#osm-lv,#osm-nl,#osm-no,#osm-nominatim,#osm-pl,#osm-pt,#osm-ru,#osm.se,#osm-strategic,#osm-ua,#osm-us,#osm-za,#osm-zh,#osmf-gm,#osrm,#openrailwaymap,#hot
 default_name = CGI:IRC User
 default_nick = CGI???
 


### PR DESCRIPTION
Add "#osm-cwg" to the channel drop-down appearing on https://irc.openstreetmap.org .

This is the IRC channel we use for Communication Working Group meetings, and between-meeting coordination. There was some [discussion of this idea in CWG meetings](https://wiki.osmfoundation.org/wiki/CWG_meeting_2018-04-12). I think it originated from a desire to be more inviting, encouraging people to join our working group or just visit our meetings.