### PR TITLE
Increase cache memory for viserion

### DIFF
--- a/roles/viserion.rb
+++ b/roles/viserion.rb
@@ -38,7 +38,7 @@ default_attributes(
     ]
   },
   :squid => {
-    :cache_mem => "12500 MB",
+    :cache_mem => "35000 MB",
     :cache_dir => "coss /store/squid/coss-01 128000 block-size=8192 max-size=262144 membufs=80"
   },
   :tilecache => {


### PR DESCRIPTION
Ram increased  from 24 GB -> 48 GB
cache_mem => "12500 MB" increased  to cache_mem => "35000 MB"

Hope those are OK values.