### PR TITLE
Reduce cache memory on viserion

### DIFF
--- a/roles/viserion.rb
+++ b/roles/viserion.rb
@@ -38,7 +38,7 @@ default_attributes(
     ]
   },
   :squid => {
-    :cache_mem => "35000 MB",
+    :cache_mem => "32000 MB",
     :cache_dir => "coss /store/squid/coss-01 128000 block-size=8192 max-size=262144 membufs=80"
   },
   :tilecache => {


### PR DESCRIPTION
Viserion started swapping , reduced cache memory from 35000 to 32000