### PR TITLE
taginfo: use pyosmium for planet updates

### DIFF
--- a/cookbooks/taginfo/recipes/default.rb
+++ b/cookbooks/taginfo/recipes/default.rb
@@ -40,7 +40,7 @@ package %w[
 
 package %w[
   sqlite3
-  osmosis
+  pyosmium
   curl
   pbzip2
 ]
@@ -196,7 +196,7 @@ node[:taginfo][:sites].each do |site|
     notifies :restart, "passenger_application[#{directory}/taginfo/web/public]"
   end
 
-  %w[taginfo/web/tmp bin data data/old download sources planet planet/log planet/replication].each do |dir|
+  %w[taginfo/web/tmp bin data data/old download sources planet planet/log].each do |dir|
     directory "#{directory}/#{dir}" do
       owner "taginfo"
       group "taginfo"
@@ -207,19 +207,6 @@ node[:taginfo][:sites].each do |site|
   remote_file "#{directory}/planet/planet.pbf" do
     action :create_if_missing
     source "https://planet.openstreetmap.org/pbf/planet-latest.osm.pbf"
-    owner "taginfo"
-    group "taginfo"
-    mode 0o644
-  end
-
-  template "#{directory}/planet/replication/configuration.txt" do
-    source "configuration.txt.erb"
-    owner "taginfo"
-    group "taginfo"
-    mode 0o644
-  end
-
-  file "#{directory}/planet/replication/download.lock" do
     owner "taginfo"
     group "taginfo"
     mode 0o644

--- a/cookbooks/taginfo/templates/default/update-planet.erb
+++ b/cookbooks/taginfo/templates/default/update-planet.erb
@@ -2,10 +2,6 @@
 
 # DO NOT EDIT - This file is being maintained by Chef
 
-# abort on error
-
-set -e
-
 # setup
 
 PLANETDIR="<%= @directory %>/planet"
@@ -13,36 +9,25 @@ LOGDIR="${PLANETDIR}/log"
 PLANETPREV="${PLANETDIR}/planet-previous.pbf"
 PLANETCURR="${PLANETDIR}/planet.pbf"
 PLANETNEW="${PLANETDIR}/planet-new.pbf"
-STATEDIR="${PLANETDIR}/replication"
-OSCFILE="${PLANETDIR}/$(date +%Y%m%d-%H%M).osc"
-OSCFILEPREV="${PLANETDIR}/previous.osc"
-
-OSMIUM=<%= @directory %>/osmium-tool/build/src/osmium
 
 # start logging
 
 exec > "${LOGDIR}/$(date +%Y%m%d-%H%M).log" 2>&1
 
-# if there are old .osc files, they have to be taken into account
+retval=1
+while [ $retval -eq 1 ]; do
+    pyosmium-up-to-date -o $PLANETNEW $PLANETCURR
+    retval=$?
+done
 
-OLDFILE="$(find "${PLANETDIR}" -name "2*-*.osc" -print)"
-if [ -z "$OLDFILE" ]
-then
-   osmosis --rri "$STATEDIR" --simc --write-xml-change "$OSCFILE"
-else
-   osmosis --rxc "$OLDFILE" --rri "$STATEDIR" --mc --simc --write-xml-change "$OSCFILE" && rm "$OLDFILE"
+if [ $retval -ne 0 ]; then
+  exit $retval
 fi
-
-# osc file is ready, create new planet file
-
-#osmosis --read-xml-change "$OSCFILE" --read-bin "$PLANETCURR" --buffer bufferCapacity=12000 --apply-change --buffer bufferCapacity=12000 --write-pbf file="$PLANETNEW"
-$OSMIUM apply-changes --verbose --fsync --output=$PLANETNEW $PLANETCURR $OSCFILE
 
 # cleanup
 
 mv "$PLANETCURR" "$PLANETPREV"
 mv "$PLANETNEW" "$PLANETCURR"
-mv "$OSCFILE" "$OSCFILEPREV"
 
 # expire old logs
 


### PR DESCRIPTION
There you go, @joto. I haven't tested the chef scripting part.

Note that pyosmium-up-to-date errors out (with a slightly confusing error message asking if the server URL is correct) when there are no new updates. I would consider that a good thing in normal operations but it might be confusing when running updates manually for some reason.