### PR TITLE
Tlie expiry on bionic still needs ruby

### DIFF
--- a/cookbooks/tile/recipes/default.rb
+++ b/cookbooks/tile/recipes/default.rb
@@ -440,6 +440,7 @@ if node[:lsb][:release].to_f >= 18.04
   package %w[
     pyosmium
     python-pyproj
+    ruby
   ]
 
   remote_directory "/usr/local/bin" do


### PR DESCRIPTION
Currently the tile expiry on pyrene is failing because ruby isn't installed:
```
$ /usr/local/bin/expire-tiles
-bash: /usr/local/bin/expire-tiles: /usr/bin/ruby: bad interpreter: No such file or directory
```