### PR TITLE
Raise maximum call limits for Lua parser funcs

### DIFF
--- a/cookbooks/mediawiki/templates/default/LocalSettings.php.erb
+++ b/cookbooks/mediawiki/templates/default/LocalSettings.php.erb
@@ -320,6 +320,13 @@ $wgNamespacesToBeSearchedDefault[NS_LANG_NL] = TRUE;
 $wgNamespacesToBeSearchedDefault[NS_LANG_RU] = TRUE;
 $wgNamespacesToBeSearchedDefault[NS_LANG_JA] = TRUE;
 
+
+# Raise expensive lua (and other function) call limits to match WP
+# Docs:  https://www.mediawiki.org/wiki/Manual:$wgExpensiveParserFunctionLimit
+# Wikipedia's Config:  https://noc.wikimedia.org/conf/highlight.php?file=CommonSettings.php
+$wgExpensiveParserFunctionLimit = 500;
+
+
 <% if @mediawiki[:site_notice] -%>
 $wgSiteNotice = "<%= @mediawiki[:site_notice] %>";
 <% end -%>

--- a/cookbooks/wiki/templates/default/mw-ext-Scribunto.inc.php.erb
+++ b/cookbooks/wiki/templates/default/mw-ext-Scribunto.inc.php.erb
@@ -19,8 +19,3 @@ $wgScribuntoUseGeSHi = true;
 
 // Use code editor
 $wgScribuntoUseCodeEditor = true;
-
-// Raise expensive lua (and other function) call limits to match WP
-// Docs:  https://www.mediawiki.org/wiki/Manual:$wgExpensiveParserFunctionLimit
-// Wikipedia's Config:  https://noc.wikimedia.org/conf/highlight.php?file=CommonSettings.php
-$wgExpensiveParserFunctionLimit = 500;

--- a/cookbooks/wiki/templates/default/mw-ext-Scribunto.inc.php.erb
+++ b/cookbooks/wiki/templates/default/mw-ext-Scribunto.inc.php.erb
@@ -19,3 +19,8 @@ $wgScribuntoUseGeSHi = true;
 
 // Use code editor
 $wgScribuntoUseCodeEditor = true;
+
+// Raise expensive lua (and other function) call limits to match WP
+// Docs:  https://www.mediawiki.org/wiki/Manual:$wgExpensiveParserFunctionLimit
+// Wikipedia's Config:  https://noc.wikimedia.org/conf/highlight.php?file=CommonSettings.php
+$wgExpensiveParserFunctionLimit = 500;


### PR DESCRIPTION
Raise expensive lua (and other function) call limits to match WP
Docs:  https://www.mediawiki.org/wiki/Manual:$wgExpensiveParserFunctionLimit
Wikipedia's Config:  https://noc.wikimedia.org/conf/highlight.php?file=CommonSettings.php