### PR TITLE
Attempt to make changeset replication more robust

### DIFF
--- a/cookbooks/planet/files/default/replication-bin/replicate-changesets
+++ b/cookbooks/planet/files/default/replication-bin/replicate-changesets
@@ -142,10 +142,6 @@ end
 class Replicator
   def initialize(config)
     @config = YAML.safe_load(File.read(config))
-    @state = YAML.safe_load(File.read(@config["state_file"]), [Time])
-    @conn = PG::Connection.connect(@config["db"])
-    # get current time from the database rather than the current system
-    @now = @conn.exec("select now() as now").map { |row| Time.parse(row["now"]) }[0]
   end
 
   def open_changesets
@@ -237,32 +233,65 @@ class Replicator
     raise "Temporary state file should be non-empty, but isn't." if File.zero?(tmp_state)
   end
 
-  def move_tmp_files_into_place!
+  def move_tmp_files_into_place!(state_file)
     data_file = data_stem + ".osm.gz"
     data_state_file = data_stem + ".state.txt"
     tmp_state = @config["state_file"] + ".tmp"
     tmp_data = data_file + ".tmp"
 
     FileUtils.mv(tmp_data, data_file)
-    FileUtils.cp(tmp_state, @config["state_file"])
-    FileUtils.mv(tmp_state, data_state_file)
+    FileUtils.cp(tmp_state, data_state_file)
 
     # fsync the files in their new locations, in case the inodes have
     # changed in the move / copy.
     fsync(data_file)
-    fsync(@config["state_file"])
     fsync(data_state_file)
 
     # sync the directory as well, to ensure that the file is reachable
     # from the dirent and has been updated to account for any allocations.
     fdirsync(File.dirname(data_file))
+    fdirsync(File.dirname(tmp_state))
+
+    # overwrite file in place, rather than copying it into place. this should
+    # mean that the flock we have on the inode doesn't go away. if this fails,
+    # then we're left with the tmp file, so we can recover from there.
+    fl.rewind
+    fl.write(File.read(tmp_state))
+    fl.flush
+    fsync(@config["state_file"])
     fdirsync(File.dirname(@config["state_file"]))
+
+    # finally, remove the tmp file.
+    FileUtils.rm(tmp_state)
+    fdirsync(File.dirname(tmp_state))
   end
 
   # saves new state (including the changeset dump xml)
   def save!
-    File.open(@config["state_file"], "r") do |fl|
+    File.open(@config["state_file"], File::RDWR) do |fl|
       fl.flock(File::LOCK_EX)
+
+      # first, try reading from the existing state file.
+      begin
+        state_data = fl.read
+        @state = YAML.safe_load(state_data, [Time])
+        raise Exception.new("Bad state file - not a Hash") unless @state.is_a?(Hash)
+
+      rescue
+        @state = nil
+      end
+
+      # if that doesn't work, try the old tmp file.
+      if @state.nil?
+        old_state_data = File.read(@config["state_file"] + ".tmp")
+        @state = YAML.safe_load(old_state_data, [Time])
+        raise Exception.new("Bad state file - not a Hash") unless @state.is_a?(Hash)
+      end
+
+      # initialise this stuff _after_ we've got the lock on the state file.
+      @conn = PG::Connection.connect(@config["db"])
+      # get current time from the database rather than the current system
+      @now = @conn.exec("select now() as now").map { |row| Time.parse(row["now"]) }[0]
 
       # try and write the files to tmp locations and then
       # move them into place later, to avoid in-progress
@@ -274,7 +303,7 @@ class Replicator
 
         write_tmp_files!(changesets)
 
-        move_tmp_files_into_place!
+        move_tmp_files_into_place!(fl)
 
         fl.flock(File::LOCK_UN)
       rescue StandardError

--- a/cookbooks/planet/files/default/replication-bin/replicate-changesets
+++ b/cookbooks/planet/files/default/replication-bin/replicate-changesets
@@ -173,7 +173,7 @@ end
 ##
 # move temporary files into their final place and rewrite the state file.
 #
-def move_tmp_files_into_place!(state_file_handle, state_file_name)
+def move_tmp_files_into_place!(state_file_name)
   data_file = data_stem + ".osm.gz"
   data_state_file = data_stem + ".state.txt"
   tmp_state = state_file_name + ".tmp"
@@ -192,26 +192,18 @@ def move_tmp_files_into_place!(state_file_handle, state_file_name)
   fdirsync(File.dirname(data_file))
   fdirsync(File.dirname(tmp_state))
 
-  # overwrite file in place, rather than copying it into place. this should
-  # mean that the flock we have on the inode doesn't go away. if this fails,
-  # then we're left with the tmp file, so we can recover from there.
-  state_file_handle.rewind
-  state_file_handle.write(File.read(tmp_state))
-  state_file_handle.flush
+  # move temporary state file into place atomically
+  FileUtils.mv(tmp_state, state_file_name)
   fsync(state_file_name)
   fdirsync(File.dirname(state_file_name))
-
-  # finally, remove the tmp file.
-  FileUtils.rm(tmp_state)
-  fdirsync(File.dirname(tmp_state))
 end
 
-def read_state(fl, state_file_name)
+def read_state(state_file_name)
   state = nil
 
   # first, try reading from the existing state file.
   begin
-    state_data = fl.read
+    state_data = File.read(state_file_name)
     state = YAML.safe_load(state_data, [Time])
     raise Exception, "Bad state file - not a Hash" unless @state.is_a?(Hash)
   rescue StandardError
@@ -297,10 +289,13 @@ class Replicator
 
   # saves new state (including the changeset dump xml)
   def save!
-    File.open(@config["state_file"], File::RDWR) do |fl|
+    state_file = @config["state_file"]
+    lock_file = @config["lock_file"]
+
+    File.open(lock_file, File::RDWR | File::CREAT) do |fl|
       fl.flock(File::LOCK_EX)
 
-      @state = read_state(fl, @config["state_file"])
+      @state = read_state(state_file)
 
       # initialise this stuff _after_ we've got the lock on the state file.
       @conn = PG::Connection.connect(@config["db"])
@@ -315,9 +310,9 @@ class Replicator
         @state["sequence"] = sequence
         @state["last_run"] = @now
 
-        write_tmp_files!(changesets, @config["state_file"], @state)
+        write_tmp_files!(changesets, state_file, @state)
 
-        move_tmp_files_into_place!(fl, @config["state_file"])
+        move_tmp_files_into_place!(state_file)
 
         fl.flock(File::LOCK_UN)
       rescue StandardError

--- a/cookbooks/planet/files/default/replication-bin/replicate-changesets
+++ b/cookbooks/planet/files/default/replication-bin/replicate-changesets
@@ -199,23 +199,11 @@ def move_tmp_files_into_place!(state_file_name)
 end
 
 def read_state(state_file_name)
-  state = nil
-
-  # first, try reading from the existing state file.
-  begin
-    state_data = File.read(state_file_name)
-    state = YAML.safe_load(state_data, [Time])
-    raise Exception, "Bad state file - not a Hash" unless @state.is_a?(Hash)
-  rescue StandardError
-    state = nil
-  end
-
-  # if that doesn't work, try the old tmp file.
-  if state.nil?
-    old_state_data = File.read(state_file_name + ".tmp")
-    @state = YAML.safe_load(old_state_data, [Time])
-    raise Exception, "Bad state file - not a Hash" unless @state.is_a?(Hash)
-  end
+  # state file will either be new version or old version - in which case we'll
+  # just end up repeating a little work.
+  state_data = File.read(state_file_name)
+  state = YAML.safe_load(state_data, [Time])
+  raise Exception, "Bad state file - not a Hash" unless state.is_a?(Hash)
 
   state
 end

--- a/cookbooks/planet/files/default/replication-bin/replicate-changesets
+++ b/cookbooks/planet/files/default/replication-bin/replicate-changesets
@@ -233,7 +233,7 @@ class Replicator
     raise "Temporary state file should be non-empty, but isn't." if File.zero?(tmp_state)
   end
 
-  def move_tmp_files_into_place!(state_file)
+  def move_tmp_files_into_place!(state_file_handle)
     data_file = data_stem + ".osm.gz"
     data_state_file = data_stem + ".state.txt"
     tmp_state = @config["state_file"] + ".tmp"
@@ -255,9 +255,9 @@ class Replicator
     # overwrite file in place, rather than copying it into place. this should
     # mean that the flock we have on the inode doesn't go away. if this fails,
     # then we're left with the tmp file, so we can recover from there.
-    fl.rewind
-    fl.write(File.read(tmp_state))
-    fl.flush
+    state_file_handle.rewind
+    state_file_handle.write(File.read(tmp_state))
+    state_file_handle.flush
     fsync(@config["state_file"])
     fdirsync(File.dirname(@config["state_file"]))
 

--- a/cookbooks/planet/files/default/replication-bin/replicate-changesets
+++ b/cookbooks/planet/files/default/replication-bin/replicate-changesets
@@ -137,6 +137,98 @@ def fdirsync(d)
 end
 
 ##
+# write the new data - changesets and state - to temporary files, and make
+# sure they're safe on disk.
+#
+def write_tmp_files!(changesets, state_file_name, state)
+  data_file = data_stem + ".osm.gz"
+  tmp_state = state_file_name + ".tmp"
+  tmp_data = data_file + ".tmp"
+
+  FileUtils.mkdir_p(File.dirname(data_file))
+  Zlib::GzipWriter.open(tmp_data) do |fh|
+    fh.write(changeset_dump(changesets))
+  end
+  File.open(tmp_state, "w") do |fh|
+    fh.write(YAML.dump(state))
+  end
+
+  # fsync the files in their old locations.
+  fsync(tmp_data)
+  fsync(tmp_state)
+
+  # sync the directory as well, to ensure that the file is reachable
+  # from the dirent and has been updated to account for any allocations.
+  fdirsync(File.dirname(tmp_data))
+  fdirsync(File.dirname(tmp_state))
+
+  # sanity check: the files we're moving into place
+  # should be non-empty.
+  raise "Temporary gzip file should exist, but doesn't." unless File.exist?(tmp_data)
+  raise "Temporary state file should exist, but doesn't." unless File.exist?(tmp_state)
+  raise "Temporary gzip file should be non-empty, but isn't." if File.zero?(tmp_data)
+  raise "Temporary state file should be non-empty, but isn't." if File.zero?(tmp_state)
+end
+
+##
+# move temporary files into their final place and rewrite the state file.
+#
+def move_tmp_files_into_place!(state_file_handle, state_file_name)
+  data_file = data_stem + ".osm.gz"
+  data_state_file = data_stem + ".state.txt"
+  tmp_state = state_file_name + ".tmp"
+  tmp_data = data_file + ".tmp"
+
+  FileUtils.mv(tmp_data, data_file)
+  FileUtils.cp(tmp_state, data_state_file)
+
+  # fsync the files in their new locations, in case the inodes have
+  # changed in the move / copy.
+  fsync(data_file)
+  fsync(data_state_file)
+
+  # sync the directory as well, to ensure that the file is reachable
+  # from the dirent and has been updated to account for any allocations.
+  fdirsync(File.dirname(data_file))
+  fdirsync(File.dirname(tmp_state))
+
+  # overwrite file in place, rather than copying it into place. this should
+  # mean that the flock we have on the inode doesn't go away. if this fails,
+  # then we're left with the tmp file, so we can recover from there.
+  state_file_handle.rewind
+  state_file_handle.write(File.read(tmp_state))
+  state_file_handle.flush
+  fsync(state_file_name)
+  fdirsync(File.dirname(state_file_name))
+
+  # finally, remove the tmp file.
+  FileUtils.rm(tmp_state)
+  fdirsync(File.dirname(tmp_state))
+end
+
+def read_state(fl, state_file_name)
+  state = nil
+
+  # first, try reading from the existing state file.
+  begin
+    state_data = fl.read
+    state = YAML.safe_load(state_data, [Time])
+    raise Exception, "Bad state file - not a Hash" unless @state.is_a?(Hash)
+  rescue StandardError
+    state = nil
+  end
+
+  # if that doesn't work, try the old tmp file.
+  if state.nil?
+    old_state_data = File.read(state_file_name + ".tmp")
+    @state = YAML.safe_load(old_state_data, [Time])
+    raise Exception, "Bad state file - not a Hash" unless @state.is_a?(Hash)
+  end
+
+  state
+end
+
+##
 # state and connections associated with getting changeset data
 # replicated to a file.
 class Replicator
@@ -203,90 +295,12 @@ class Replicator
     @config["data_dir"] + format("/%03d/%03d/%03d", sequence / 1000000, (sequence / 1000) % 1000, (sequence % 1000))
   end
 
-  def write_tmp_files!(changesets)
-    data_file = data_stem + ".osm.gz"
-    tmp_state = @config["state_file"] + ".tmp"
-    tmp_data = data_file + ".tmp"
-
-    FileUtils.mkdir_p(File.dirname(data_file))
-    Zlib::GzipWriter.open(tmp_data) do |fh|
-      fh.write(changeset_dump(changesets))
-    end
-    File.open(tmp_state, "w") do |fh|
-      fh.write(YAML.dump(@state))
-    end
-
-    # fsync the files in their old locations.
-    fsync(tmp_data)
-    fsync(tmp_state)
-
-    # sync the directory as well, to ensure that the file is reachable
-    # from the dirent and has been updated to account for any allocations.
-    fdirsync(File.dirname(tmp_data))
-    fdirsync(File.dirname(tmp_state))
-
-    # sanity check: the files we're moving into place
-    # should be non-empty.
-    raise "Temporary gzip file should exist, but doesn't." unless File.exist?(tmp_data)
-    raise "Temporary state file should exist, but doesn't." unless File.exist?(tmp_state)
-    raise "Temporary gzip file should be non-empty, but isn't." if File.zero?(tmp_data)
-    raise "Temporary state file should be non-empty, but isn't." if File.zero?(tmp_state)
-  end
-
-  def move_tmp_files_into_place!(state_file_handle)
-    data_file = data_stem + ".osm.gz"
-    data_state_file = data_stem + ".state.txt"
-    tmp_state = @config["state_file"] + ".tmp"
-    tmp_data = data_file + ".tmp"
-
-    FileUtils.mv(tmp_data, data_file)
-    FileUtils.cp(tmp_state, data_state_file)
-
-    # fsync the files in their new locations, in case the inodes have
-    # changed in the move / copy.
-    fsync(data_file)
-    fsync(data_state_file)
-
-    # sync the directory as well, to ensure that the file is reachable
-    # from the dirent and has been updated to account for any allocations.
-    fdirsync(File.dirname(data_file))
-    fdirsync(File.dirname(tmp_state))
-
-    # overwrite file in place, rather than copying it into place. this should
-    # mean that the flock we have on the inode doesn't go away. if this fails,
-    # then we're left with the tmp file, so we can recover from there.
-    state_file_handle.rewind
-    state_file_handle.write(File.read(tmp_state))
-    state_file_handle.flush
-    fsync(@config["state_file"])
-    fdirsync(File.dirname(@config["state_file"]))
-
-    # finally, remove the tmp file.
-    FileUtils.rm(tmp_state)
-    fdirsync(File.dirname(tmp_state))
-  end
-
   # saves new state (including the changeset dump xml)
   def save!
     File.open(@config["state_file"], File::RDWR) do |fl|
       fl.flock(File::LOCK_EX)
 
-      # first, try reading from the existing state file.
-      begin
-        state_data = fl.read
-        @state = YAML.safe_load(state_data, [Time])
-        raise Exception.new("Bad state file - not a Hash") unless @state.is_a?(Hash)
-
-      rescue
-        @state = nil
-      end
-
-      # if that doesn't work, try the old tmp file.
-      if @state.nil?
-        old_state_data = File.read(@config["state_file"] + ".tmp")
-        @state = YAML.safe_load(old_state_data, [Time])
-        raise Exception.new("Bad state file - not a Hash") unless @state.is_a?(Hash)
-      end
+      @state = read_state(fl, @config["state_file"])
 
       # initialise this stuff _after_ we've got the lock on the state file.
       @conn = PG::Connection.connect(@config["db"])
@@ -301,9 +315,9 @@ class Replicator
         @state["sequence"] = sequence
         @state["last_run"] = @now
 
-        write_tmp_files!(changesets)
+        write_tmp_files!(changesets, @config["state_file"], @state)
 
-        move_tmp_files_into_place!(fl)
+        move_tmp_files_into_place!(fl, @config["state_file"])
 
         fl.flock(File::LOCK_UN)
       rescue StandardError

--- a/cookbooks/planet/files/default/replication-bin/replicate-changesets
+++ b/cookbooks/planet/files/default/replication-bin/replicate-changesets
@@ -137,10 +137,32 @@ def fdirsync(d)
 end
 
 ##
+# creates an XML file containing the changeset information from the
+# list of changesets output by open_changesets.
+#
+def changeset_dump(changesets)
+  doc = XML::Document.new
+  doc.root = XML::Node.new("osm")
+  { "version" => "0.6",
+    "generator" => "replicate_changesets.rb",
+    "copyright" => "OpenStreetMap and contributors",
+    "attribution" => "https://www.openstreetmap.org/copyright",
+    "license" => "https://opendatacommons.org/licenses/odbl/1-0/" }
+    .each { |k, v| doc.root[k] = v }
+
+  builder = ChangesetBuilder.new(@now, @conn)
+  changesets.each do |cs|
+    doc.root << builder.changeset_xml(cs)
+  end
+
+  doc.to_s
+end
+
+##
 # write the new data - changesets and state - to temporary files, and make
 # sure they're safe on disk.
 #
-def write_tmp_files!(changesets, state_file_name, state)
+def write_tmp_files!(data_stem, changesets, state_file_name, state)
   data_file = data_stem + ".osm.gz"
   tmp_state = state_file_name + ".tmp"
   tmp_data = data_file + ".tmp"
@@ -173,7 +195,7 @@ end
 ##
 # move temporary files into their final place and rewrite the state file.
 #
-def move_tmp_files_into_place!(state_file_name)
+def move_tmp_files_into_place!(data_stem, state_file_name)
   data_file = data_stem + ".osm.gz"
   data_state_file = data_stem + ".state.txt"
   tmp_state = state_file_name + ".tmp"
@@ -247,26 +269,6 @@ class Replicator
     changesets.sort_by(&:id)
   end
 
-  # creates an XML file containing the changeset information from the
-  # list of changesets output by open_changesets.
-  def changeset_dump(changesets)
-    doc = XML::Document.new
-    doc.root = XML::Node.new("osm")
-    { "version" => "0.6",
-      "generator" => "replicate_changesets.rb",
-      "copyright" => "OpenStreetMap and contributors",
-      "attribution" => "https://www.openstreetmap.org/copyright",
-      "license" => "https://opendatacommons.org/licenses/odbl/1-0/" }
-      .each { |k, v| doc.root[k] = v }
-
-    builder = ChangesetBuilder.new(@now, @conn)
-    changesets.each do |cs|
-      doc.root << builder.changeset_xml(cs)
-    end
-
-    doc.to_s
-  end
-
   def sequence
     @state.key?("sequence") ? @state["sequence"] + 1 : 0
   end
@@ -298,9 +300,9 @@ class Replicator
         @state["sequence"] = sequence
         @state["last_run"] = @now
 
-        write_tmp_files!(changesets, state_file, @state)
+        write_tmp_files!(data_stem, changesets, state_file, @state)
 
-        move_tmp_files_into_place!(state_file)
+        move_tmp_files_into_place!(data_stem, state_file)
 
         fl.flock(File::LOCK_UN)
       rescue StandardError

--- a/cookbooks/planet/templates/default/changesets.conf.erb
+++ b/cookbooks/planet/templates/default/changesets.conf.erb
@@ -1,3 +1,4 @@
 state_file: /store/planet/replication/changesets/state.yaml
+lock_file: /store/planet/replication/changesets/state.lock
 db: host=<%= node[:web][:database_host] %> dbname=openstreetmap user=planetdiff password=<%= @password %>
 data_dir: /store/planet/replication/changesets


### PR DESCRIPTION
Attempt to make changeset replication more robust to overruns and concurrent executions by not copying the state file, instead overwrite it in-place. Also, try to make the recovery process more robust if a zero-length state file is found.