### PR TITLE
automatic double redirect resolution for the Wiki

### DIFF
--- a/cookbooks/mediawiki/templates/default/LocalSettings.php.erb
+++ b/cookbooks/mediawiki/templates/default/LocalSettings.php.erb
@@ -236,6 +236,9 @@ $wgShowIPinHeader = FALSE;
 # Job Runs by cron
 $wgJobRunRate = 0;
 
+# dissolves double redirects automatically
+$wgFixDoubleRedirects = TRUE;
+
 # Allow external images from a few sites
 $wgAllowExternalImagesFrom = array( 'http://tile.openstreetmap.org/', 'http://svenanders.openstreetmap.de/', 'http://josm.openstreetmap.de/', 'http://trac.openstreetmap.org/', 'http://rweait.dev.openstreetmap.org/' );
 


### PR DESCRIPTION
This changes a setting in MediaWiki, so that the system resolves double redirects (redirections to redirections to wiki pages) automatically. 
MediaWiki handbook entry: https://www.mediawiki.org/wiki/Help:Redirects#Double_redirects
Discussion with a wiki admin about potential downsides of this: https://wiki.openstreetmap.org/wiki/User_talk:Lyx#Automatic_double_redirect_resolution

<s>In addition, a reference to a non-functional web site is removed. </s>