### PR TITLE
Add firewall_rule helper support

### DIFF
--- a/cookbooks/ftp/recipes/default.rb
+++ b/cookbooks/ftp/recipes/default.rb
@@ -50,4 +50,5 @@ firewall_rule "accept-ftp-tcp" do
   proto "tcp"
   dest_ports "ftp"
   source_ports "-"
+  helper "ftp"
 end

--- a/cookbooks/networking/definitions/firewall_rule.rb
+++ b/cookbooks/networking/definitions/firewall_rule.rb
@@ -26,7 +26,8 @@ define :firewall_rule, :action => :accept do
     :dest_ports => params[:dest_ports] || "-",
     :source_ports => params[:source_ports] || "-",
     :rate_limit => params[:rate_limit] || "-",
-    :connection_limit => params[:connection_limit] || "-"
+    :connection_limit => params[:connection_limit] || "-",
+    :helper => params[:helper] || "-"
   ]
 
   if params[:family].nil?

--- a/cookbooks/networking/templates/default/shorewall-rules.erb
+++ b/cookbooks/networking/templates/default/shorewall-rules.erb
@@ -6,8 +6,8 @@
 SECTION NEW
 <% end -%>
 
-# ACTION	SOURCE	DEST	PROTO		DEST		SOURCE	ORIGINAL	RATE	USER	MARK	CONNLIMIT
-#						PORTS		PORTS	DEST		LIMIT
+# ACTION       SOURCE    DEST  PROTO           DEST            SOURCE  ORIGINAL        RATE    USER/   MARK    CONNLIMIT  TIME  HEADERS  SWITCH  HELPER
+#                                              PORTS           PORTS   DEST            LIMIT   GROUP
 <% node[:networking][:firewall][@family].each do |r| # ~FC034 -%>
-<%= r[:action] %>		<%= r[:source] %>	<%= r[:dest] %>	<%= r[:proto] %>		<%= r[:dest_ports] %>	<%= r[:source_ports] %>	-	<%= r[:rate_limit] %>	-	-	<%= r[:connection_limit] %>
+<%= r[:action] %>		<%= r[:source] %>	<%= r[:dest] %>	<%= r[:proto] %>		<%= r[:dest_ports] %>	<%= r[:source_ports] %>	-	<%= r[:rate_limit] %>	-	-	<%= r[:connection_limit] %> -	-	- <%= r[:helper] %>
 <% end -%>


### PR DESCRIPTION
Adds helper support to firewall_rule.

Enable netfilter FTP helper for ftp cookbook.