### PR TITLE
Set trace_use_job_queue explicitly

### DIFF
--- a/cookbooks/web/resources/rails_port.rb
+++ b/cookbooks/web/resources/rails_port.rb
@@ -272,6 +272,7 @@ action :create do
 
     line.gsub!(/^( *)require_terms_seen:.*$/, "\\1require_terms_seen: true")
     line.gsub!(/^( *)require_terms_agreed:.*$/, "\\1require_terms_agreed: true")
+    line.gsub!(/^( *)trace_use_job_queue:.*$/, "\\1trace_use_job_queue: false")
 
     line
   end


### PR DESCRIPTION
I plan to change the default for `trace_use_job_queue` to `true` in upstream, so that new deployments work out-of-the-box (and also make it easier for developers to use locally). However, it's not quite ready for prime-time on osm.org so we still want to use the external importer for now.

I've followed the existing example for other options in this file, but please note that I haven't tested running this cookbook since we don't have test-kitchen set up for it yet.