### PR TITLE
Set $wgCanonicalServer to change links in confirmation emails to https

### DIFF
--- a/cookbooks/mediawiki/templates/default/LocalSettings.php.erb
+++ b/cookbooks/mediawiki/templates/default/LocalSettings.php.erb
@@ -25,6 +25,7 @@ $wgScriptExtension  = ".php";
 ## The protocol and server name to use in fully-qualified URLs
 $wgServer           = "//<%= @name %>";
 $wgInternalServer   = 'https://<%= @name %>';
+$wgCanonicalServer  = 'https://<%= @name %>';
 
 $wgSecureLogin = true;
 $wgDefaultUserOptions['prefershttps'] = 1;


### PR DESCRIPTION
The wiki currently sends out e-mails for e-mail address confirmation containing http links. This change intends to make Mediawiki use https instead. 
Relevant manual page: https://www.mediawiki.org/wiki/Manual:$wgCanonicalServer

This fixes https://trac.openstreetmap.org/ticket/5466. 