### PR TITLE
Link to explanantions when not to use the form is 3-fold redirect

### DIFF
--- a/cookbooks/dmca/files/default/html/index.php
+++ b/cookbooks/dmca/files/default/html/index.php
@@ -37,7 +37,7 @@ $form->addElement('static', null, '<p>To file a copyright infringement notificat
 <li>A statement that the complaining party has a good faith belief that use of the material in the manner complained of is not authorized by the copyright owner, its agent, or the law.
 <li>A statement that the information in the notification is accurate and, under penalty of perjury, that the complaining party is authorized to act on behalf of the owner of an exclusive right that is allegedly infringed.
 </ul><p>To expedite our ability to process your request, such written notice should be sent to our designated agent via our online copyright complaint form below.</p>
-<p>This form is only for cases where you believe that material on OpenStreetMap\'s websites or in its geodata database infringes your copyright or that of your clients. For example, you claim someone has copied material from a map belonging to you. If you have come here for another reason, <a href="http://www.osmfoundation.org/wiki/License/Takedown_procedure/When_To_Use_The_Form">Go here</a>.</p>');
+<p>This form is only for cases where you believe that material on OpenStreetMap\'s websites or in its geodata database infringes your copyright or that of your clients. For example, you claim someone has copied material from a map belonging to you. If you have come here for another reason, <a href="https://wiki.osmfoundation.org/wiki/Licence_and_Legal_FAQ/Takedown_procedure/When_To_Use_The_Form">Go here</a>.</p>');
 
 $form->addElement('text', 'url',                'URL of Allegedly Infringing Material', array('size' => 50, 'maxlength' => 255));
 $form->addRule('url', 'Please enter URL of Allegedly Infringing Material', 'required', null, 'client');


### PR DESCRIPTION
This replaces the URL with the correct one (https://wiki.osmfoundation.org/wiki/Licence_and_Legal_FAQ/Takedown_procedure/When_To_Use_The_Form)