### PR TITLE
Allow sysops to modify interwiki table

### DIFF
--- a/cookbooks/mediawiki/resources/site.rb
+++ b/cookbooks/mediawiki/resources/site.rb
@@ -262,6 +262,7 @@ action :create do
 
   mediawiki_extension "Interwiki" do
     site new_resource.site
+    template "mw-ext-Interwiki.inc.php.erb"
     update_site false
   end
 

--- a/cookbooks/mediawiki/templates/default/mw-ext-Interwiki.inc.php.erb
+++ b/cookbooks/mediawiki/templates/default/mw-ext-Interwiki.inc.php.erb
@@ -1,0 +1,5 @@
+<?php
+# DO NOT EDIT - This file is being maintained by Chef
+
+# allow sysops to modify interwiki table
+$wgGroupPermissions['sysop']['interwiki'] = true;


### PR DESCRIPTION
Assigns ```interwiki``` permission to sysops, so they can modify the interwiki table. 
I suggested this change when we were discussing about renaming the project namespace to ```Wiki```. I think removing the interwiki link with this prefix is a prerequisite. 

Link to the discussion: https://wiki.openstreetmap.org/w/index.php?title=Talk:Wiki&diff=prev&oldid=1844371
Link to MediaWiki docs: https://www.mediawiki.org/wiki/Extension:Interwiki#Installation

Closes openstreetmap/operations#296. 