### PR TITLE
Re-add interwiki extension (accidentally removed previously)

### DIFF
--- a/cookbooks/mediawiki/templates/default/mw-ext-Interwiki.inc.php.erb
+++ b/cookbooks/mediawiki/templates/default/mw-ext-Interwiki.inc.php.erb
@@ -1,5 +1,6 @@
 <?php
 # DO NOT EDIT - This file is being maintained by Chef
+wfLoadExtension( 'Interwiki' );
 
 # allow sysops to modify interwiki table
 $wgGroupPermissions['sysop']['interwiki'] = true;


### PR DESCRIPTION
In #232, I unintentionally removed the interwiki extension. Sorry, I misunderstood Chef! Nothing bad happened, the permission to modify the interwikis is just pretty useless if the extension is missing ;-). 