### PR TITLE
Rename meta namespace in main wiki

### DIFF
--- a/cookbooks/wiki/recipes/default.rb
+++ b/cookbooks/wiki/recipes/default.rb
@@ -47,7 +47,7 @@ mediawiki_site "wiki.openstreetmap.org" do
   email_sender "wiki@noreply.openstreetmap.org"
   email_sender_name "OpenStreetMap Wiki"
 
-  metanamespace "OpenStreetMap"
+  metanamespace "Wiki"
 
   recaptcha_public_key "6LdFIQATAAAAAMwtHeI8KDgPqvRbXeNYSq1gujKz"
   recaptcha_private_key passwords["recaptcha"]


### PR DESCRIPTION
The current name of the project/meta namespace was considered confusing, because the pages in this namespace contain organisational content about the wiki (see https://wiki.openstreetmap.org/wiki/OpenStreetMap:VisualEditor for instance), the name ```OpenStreetMap``` implied however some relevance for OSM itself. 

Renaming was discussed at https://wiki.openstreetmap.org/w/index.php?title=Talk:Wiki&oldid=1846962#Renaming_the_project_name_space
I already carried out some manual fixing to avoid breaking links and I will check again after renaming. 
