### PR TITLE
add MultiMaps extension to wikis

### DIFF
--- a/cookbooks/mediawiki/resources/site.rb
+++ b/cookbooks/mediawiki/resources/site.rb
@@ -430,6 +430,13 @@ action :create do
     update_site false
   end
 
+  mediawiki_extension "MultiMaps" do
+    site new_resource.site
+    template "mw-ext-MultiMaps.inc.php.erb"
+    reference "master"
+    update_site false
+  end
+
   mediawiki_extension "Mantle" do
     site new_resource.site
     update_site false

--- a/cookbooks/mediawiki/templates/default/mw-ext-MultiMaps.inc.php.erb
+++ b/cookbooks/mediawiki/templates/default/mw-ext-MultiMaps.inc.php.erb
@@ -1,0 +1,17 @@
+<?php
+# DO NOT EDIT - This file is being maintained by Chef
+
+require_once "$IP/extensions/MultiMaps/MultiMaps.php";
+
+# Array of String. Array containing all the mapping services that will be made available to the user.
+# First value - default service, which will be used if the service is not in the parameters
+# Values may be a valid name of class based on class BaseMapService or some string and an array if they 
+# denote different tiles within a BaseMapService
+$egMultiMaps_MapServices = [
+  'Leaflet',
+  'transport' => [
+    'service' => 'Leaflet',
+    'attribution' => '&copy; <a href="https://osm.org/copyright">OpenStreetMap contributors</a>. Tiles courtesy of <a href="https://www.thunderforest.com/" target="_blank">Andy Allan</a>',
+    'source' => 'https://tile.thunderforest.com/transport/{z}/{x}/{y}.png',
+  ],
+];


### PR DESCRIPTION
Closes openstreetmap/operations#252 by adding MultiMaps to all wikis. The following steps are needed to finally replace unmaintained SlippyMap extension

- [ ] @gravitystorm obtain an API key from thunderforest.com for displaying transport tiles
- [ ] merge this PR
- [ ] replace all calls to SlippyMap with MultiMaps (I am not sure if the extension was used on any of the private wikis at all, but it was installed) - I can do that for the main wiki using a bot, but I will have to follow Automated edits code of conduct meaning it will take its time. You might want to consider if map extensions are needed in the private wikis, in case they are not used. 
- [ ] remove SlippyMap extension from the configuration