### PR TITLE
add tile HTTPS address to external image whitelist

### DIFF
--- a/cookbooks/mediawiki/templates/default/LocalSettings.php.erb
+++ b/cookbooks/mediawiki/templates/default/LocalSettings.php.erb
@@ -245,7 +245,7 @@ $wgJobRunRate = 0;
 $wgFixDoubleRedirects = TRUE;
 
 # Allow external images from a few sites
-$wgAllowExternalImagesFrom = array( 'http://tile.openstreetmap.org/', 'http://josm.openstreetmap.de/', 'http://trac.openstreetmap.org/', 'http://rweait.dev.openstreetmap.org/' );
+$wgAllowExternalImagesFrom = array( 'http://tile.openstreetmap.org/', 'https://tile.openstreetmap.org', 'http://josm.openstreetmap.de/', 'http://trac.openstreetmap.org/', 'http://rweait.dev.openstreetmap.org/' );
 
 $wgNoFollowDomainExceptions = array( 'www.openstreetmap.org', 'josm.openstreetmap.de', 'taginfo.openstreetmap.org', 'blog.openstreetmap.org', 'wiki.osmfoundation.org' );
 


### PR DESCRIPTION
I suggest to keep the HTTP address for now to avoid breaking pages, but it causes mixed content warnings in the main wiki.