### PR TITLE
Resolve multiple Cookstyle warnings

### DIFF
--- a/cookbooks/accounts/metadata.rb
+++ b/cookbooks/accounts/metadata.rb
@@ -3,6 +3,5 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Accounts management"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"

--- a/cookbooks/accounts/recipes/default.rb
+++ b/cookbooks/accounts/recipes/default.rb
@@ -23,12 +23,12 @@ administrators = []
 
 search(:accounts, "*:*").each do |account|
   name = account["id"]
-  details = node[:accounts][:users][name] || {}
+  details = node["accounts"]["users"][name] || {}
 
   if details[:status]
     group_members = details[:members] || account["members"] || []
-    user_home = details[:home] || account["home"] || "#{node[:accounts][:home]}/#{name}"
-    manage_user_home = details.fetch(:manage_home, account.fetch("manage_home", node[:accounts][:manage_home]))
+    user_home = details[:home] || account["home"] || "#{node['accounts']['home']}/#{name}"
+    manage_user_home = details.fetch(:manage_home, account.fetch("manage_home", node["accounts"]["manage_home"]))
 
     group_members = group_members.collect(&:to_s).sort
 
@@ -36,12 +36,12 @@ search(:accounts, "*:*").each do |account|
     when "role"
       user_shell = "/usr/sbin/nologin"
     when "user", "administrator"
-      user_shell = details[:shell] || account["shell"] || node[:accounts][:shell]
+      user_shell = details[:shell] || account["shell"] || node["accounts"]["shell"]
     end
 
     group name.to_s do
       gid account["uid"].to_i
-      members group_members & node[:etc][:passwd].keys
+      members group_members & node["etc"]["passwd"].keys
     end
 
     user name.to_s do
@@ -58,7 +58,7 @@ search(:accounts, "*:*").each do |account|
       source name.to_s
       owner name.to_s
       group name.to_s
-      mode 0o755
+      mode "755"
       files_owner name.to_s
       files_group name.to_s
       files_mode 0o644
@@ -85,7 +85,7 @@ search(:accounts, "*:*").each do |account|
   end
 end
 
-node[:accounts][:groups].each do |name, details|
+node["accounts"]["groups"].each do |name, details|
   group name do
     action :modify
     members details[:members]

--- a/cookbooks/apache/metadata.rb
+++ b/cookbooks/apache/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures apache"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "munin"

--- a/cookbooks/apache/recipes/default.rb
+++ b/cookbooks/apache/recipes/default.rb
@@ -25,14 +25,14 @@ package %w[
 ]
 
 %w[event itk prefork worker].each do |mpm|
-  next if mpm == node[:apache][:mpm]
+  next if mpm == node["apache"]["mpm"]
 
   apache_module "mpm_#{mpm}" do
     action [:disable]
   end
 end
 
-apache_module "mpm_#{node[:apache][:mpm]}" do
+apache_module "mpm_#{node['apache']['mpm']}" do
   action [:enable]
 end
 
@@ -49,7 +49,7 @@ template "/etc/apache2/ports.conf" do
   source "ports.conf.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
 end
 
 service "apache2" do
@@ -71,7 +71,7 @@ apache_module "deflate" do
   conf "deflate.conf.erb"
 end
 
-if node[:apache][:reqtimeout]
+if node["apache"]["reqtimeout"]
   apache_module "reqtimeout" do
     action [:enable]
   end

--- a/cookbooks/apache/resources/conf.rb
+++ b/cookbooks/apache/resources/conf.rb
@@ -48,7 +48,7 @@ action_class do
       source new_resource.template
       owner "root"
       group "root"
-      mode 0o644
+      mode "644"
       variables new_resource.variables
     end
   end

--- a/cookbooks/apache/resources/module.rb
+++ b/cookbooks/apache/resources/module.rb
@@ -33,7 +33,7 @@ action :install do
       source new_resource.conf
       owner "root"
       group "root"
-      mode 0o644
+      mode "644"
       variables new_resource.variables
     end
   end

--- a/cookbooks/apache/resources/site.rb
+++ b/cookbooks/apache/resources/site.rb
@@ -32,7 +32,7 @@ action :create do
     source new_resource.template
     owner "root"
     group "root"
-    mode 0o644
+    mode "644"
     variables new_resource.variables.merge(:name => new_resource.site, :directory => site_directory)
   end
 end

--- a/cookbooks/apt/metadata.rb
+++ b/cookbooks/apt/metadata.rb
@@ -3,7 +3,6 @@ maintainer       "Tom Hughes"
 maintainer_email "tom@compton.nu"
 license          "Apache-2.0"
 description      "Installs/Configures apt"
-long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version          "0.1"
 supports         "debian"
 supports         "ubuntu"

--- a/cookbooks/apt/recipes/default.rb
+++ b/cookbooks/apt/recipes/default.rb
@@ -32,15 +32,15 @@ template "/etc/apt/preferences.d/99-chef" do
   source "preferences.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
 end
 
 apt_update "/etc/apt/sources.list" do
   action :nothing
 end
 
-archive_host = if node[:country]
-                 "#{node[:country]}.archive.ubuntu.com"
+archive_host = if node["country"]
+                 "#{node['country']}.archive.ubuntu.com"
                else
                  "archive.ubuntu.com"
                end
@@ -49,13 +49,13 @@ template "/etc/apt/sources.list" do
   source "sources.list.erb"
   owner "root"
   group "root"
-  mode 0o644
-  variables :archive_host => archive_host, :codename => node[:lsb][:codename]
+  mode "644"
+  variables :archive_host => archive_host, :codename => node["lsb"]["codename"]
   notifies :update, "apt_update[/etc/apt/sources.list]", :immediately
 end
 
 repository_actions = Hash.new do |_, repository|
-  node[:apt][:sources].include?(repository) ? :add : :remove
+  node["apt"]["sources"].include?(repository) ? :add : :remove
 end
 
 apt_repository "brightbox-ruby-ng" do
@@ -96,7 +96,7 @@ end
 apt_repository "management-component-pack" do
   action repository_actions["management-component-pack"]
   uri "https://downloads.linux.hpe.com/SDR/repo/mcp"
-  distribution "#{node[:lsb][:codename]}/current-gen9"
+  distribution "#{node['lsb']['codename']}/current-gen9"
   components ["non-free"]
   key "C208ADDE26C2B797"
 end
@@ -143,7 +143,7 @@ end
 apt_repository "postgresql" do
   action repository_actions["postgresql"]
   uri "https://apt.postgresql.org/pub/repos/apt"
-  distribution "#{node[:lsb][:codename]}-pgdg"
+  distribution "#{node['lsb']['codename']}-pgdg"
   components ["main"]
   key "7FCC7D46ACCC4CF8"
 end
@@ -159,7 +159,7 @@ end
 package "unattended-upgrades"
 
 if Dir.exist?("/usr/share/unattended-upgrades")
-  auto_upgrades = if node[:apt][:unattended_upgrades][:enable]
+  auto_upgrades = if node["apt"]["unattended_upgrades"]["enable"]
                     IO.read("/usr/share/unattended-upgrades/20auto-upgrades")
                   else
                     IO.read("/usr/share/unattended-upgrades/20auto-upgrades-disabled")
@@ -168,7 +168,7 @@ if Dir.exist?("/usr/share/unattended-upgrades")
   file "/etc/apt/apt.conf.d/20auto-upgrades" do
     user "root"
     group "root"
-    mode 0o644
+    mode "644"
     content auto_upgrades
   end
 end
@@ -177,5 +177,5 @@ template "/etc/apt/apt.conf.d/60chef" do
   source "apt.conf.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
 end

--- a/cookbooks/backup/metadata.rb
+++ b/cookbooks/backup/metadata.rb
@@ -3,6 +3,5 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures backup.openstreetmap.org"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"

--- a/cookbooks/backup/recipes/default.rb
+++ b/cookbooks/backup/recipes/default.rb
@@ -25,18 +25,18 @@ package %w[
 directory "/store/backup" do
   owner "osmbackup"
   group "osmbackup"
-  mode 0o2755
+  mode "2755"
 end
 
 cookbook_file "/usr/local/bin/expire-backups" do
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end
 
 template "/etc/cron.daily/expire-backups" do
   source "expire.cron.erb"
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end

--- a/cookbooks/bind/metadata.rb
+++ b/cookbooks/bind/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Configures bind"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "networking"

--- a/cookbooks/bind/recipes/default.rb
+++ b/cookbooks/bind/recipes/default.rb
@@ -19,7 +19,7 @@
 
 include_recipe "networking"
 
-clients = search(:node, "roles:#{node[:bind][:clients]}")
+clients = search(:node, "roles:#{node['bind']['clients']}")
 
 ipv4_clients = clients.collect do |client|
   client.ipaddresses(:family => :inet)
@@ -40,7 +40,7 @@ template "/etc/bind/named.conf.local" do
   source "named.local.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
   notifies :restart, "service[bind9]"
 end
 
@@ -48,7 +48,7 @@ template "/etc/bind/named.conf.options" do
   source "named.options.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
   variables :ipv4_clients => ipv4_clients, :ipv6_clients => ipv6_clients
   notifies :restart, "service[bind9]"
 end
@@ -57,7 +57,7 @@ template "/etc/bind/db.10" do
   source "db.10.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
   notifies :reload, "service[bind9]"
 end
 

--- a/cookbooks/blog/metadata.rb
+++ b/cookbooks/blog/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures Blog services"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "wordpress"

--- a/cookbooks/blog/recipes/default.rb
+++ b/cookbooks/blog/recipes/default.rb
@@ -24,7 +24,7 @@ passwords = data_bag_item("blog", "passwords")
 directory "/srv/blog.openstreetmap.org" do
   owner "wordpress"
   group "wordpress"
-  mode 0o755
+  mode "755"
 end
 
 wordpress_site "blog.openstreetmap.org" do
@@ -110,6 +110,6 @@ template "/etc/cron.daily/blog-backup" do
   source "backup.cron.erb"
   owner "root"
   group "root"
-  mode 0o750
+  mode "750"
   variables :passwords => passwords
 end

--- a/cookbooks/blogs/metadata.rb
+++ b/cookbooks/blogs/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Configures server-info web site"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "apache"

--- a/cookbooks/blogs/recipes/default.rb
+++ b/cookbooks/blogs/recipes/default.rb
@@ -33,7 +33,7 @@ gem_package "bundler"
 directory "/srv/blogs.openstreetmap.org" do
   owner "blogs"
   group "blogs"
-  mode 0o755
+  mode "755"
 end
 
 git "/srv/blogs.openstreetmap.org" do

--- a/cookbooks/cgiirc/metadata.rb
+++ b/cookbooks/cgiirc/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures cgiirc"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "apache"

--- a/cookbooks/cgiirc/recipes/default.rb
+++ b/cookbooks/cgiirc/recipes/default.rb
@@ -27,14 +27,14 @@ template "/etc/cgiirc/cgiirc.config" do
   source "cgiirc.config.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
 end
 
 template "/etc/cgiirc/ipaccess" do
   source "ipaccess.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
   variables :blocks => blocks["addresses"]
 end
 

--- a/cookbooks/chef/attributes/default.rb
+++ b/cookbooks/chef/attributes/default.rb
@@ -1,5 +1,5 @@
 # Add the opscode APT source for chef
-default[:apt][:sources] = node[:apt][:sources] | ["opscode"]
+default[:apt][:sources] = node["apt"]["sources"] | ["opscode"]
 
 # Set the default server version
 default[:chef][:server][:version] = "12.17.33"

--- a/cookbooks/chef/metadata.rb
+++ b/cookbooks/chef/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures chef"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "apache"

--- a/cookbooks/chef/recipes/default.rb
+++ b/cookbooks/chef/recipes/default.rb
@@ -17,13 +17,13 @@
 # limitations under the License.
 #
 
-chef_version = node[:chef][:client][:version]
+chef_version = node["chef"]["client"]["version"]
 chef_package = "chef_#{chef_version}-1_amd64.deb"
 
 directory "/var/cache/chef" do
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end
 
 Dir.glob("/var/cache/chef/chef_*.deb").each do |deb|
@@ -36,10 +36,10 @@ Dir.glob("/var/cache/chef/chef_*.deb").each do |deb|
 end
 
 remote_file "/var/cache/chef/#{chef_package}" do
-  source "https://packages.chef.io/files/stable/chef/#{chef_version}/ubuntu/#{node[:lsb][:release]}/#{chef_package}"
+  source "https://packages.chef.io/files/stable/chef/#{chef_version}/ubuntu/#{node['lsb']['release']}/#{chef_package}"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
   backup false
   ignore_failure true
 end
@@ -52,59 +52,59 @@ end
 directory "/etc/chef" do
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end
 
 template "/etc/chef/client.rb" do
   source "client.rb.erb"
   owner "root"
   group "root"
-  mode 0o640
+  mode "640"
 end
 
 file "/etc/chef/client.pem" do
   owner "root"
   group "root"
-  mode 0o400
+  mode "400"
 end
 
 template "/etc/chef/report.rb" do
   source "report.rb.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
 end
 
 template "/etc/logrotate.d/chef" do
   source "logrotate.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
 end
 
 directory "/etc/chef/trusted_certs" do
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end
 
 template "/etc/chef/trusted_certs/verisign.pem" do
   source "verisign.pem.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
 end
 
-directory node[:ohai][:plugin_dir] do
+directory node["ohai"]["plugin_dir"] do
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end
 
 directory "/var/log/chef" do
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end
 
 systemd_service "chef-client" do

--- a/cookbooks/chef/recipes/repository.rb
+++ b/cookbooks/chef/recipes/repository.rb
@@ -24,11 +24,11 @@ keys = data_bag_item("chef", "keys")
 directory "/var/lib/chef" do
   owner "chefrepo"
   group "chefrepo"
-  mode 0o2775
+  mode "2775"
 end
 
 %w[public private].each do |repository|
-  repository_directory = node[:chef][:"#{repository}_repository"]
+  repository_directory = node["chef"][:"#{repository}_repository"]
 
   git "/var/lib/chef/#{repository}" do
     action :checkout
@@ -41,28 +41,28 @@ end
   directory "/var/lib/chef/#{repository}/.chef" do
     owner "chefrepo"
     group "chefrepo"
-    mode 0o2775
+    mode "2775"
   end
 
   file "/var/lib/chef/#{repository}/.chef/client.pem" do
     content keys["git"].join("\n")
     owner "chefrepo"
     group "chefrepo"
-    mode 0o660
+    mode "660"
   end
 
   cookbook_file "/var/lib/chef/#{repository}/.chef/knife.rb" do
     source "knife.rb"
     owner "chefrepo"
     group "chefrepo"
-    mode 0o660
+    mode "660"
   end
 
   template "#{repository_directory}/hooks/post-receive" do
     source "post-receive.erb"
     owner "chefrepo"
     group "chefrepo"
-    mode 0o750
+    mode "750"
     variables :repository => repository
   end
 end

--- a/cookbooks/chef/recipes/server.rb
+++ b/cookbooks/chef/recipes/server.rb
@@ -55,7 +55,7 @@ template "/etc/opscode/chef-server.rb" do
   source "server.rb.erb"
   owner "root"
   group "root"
-  mode 0o640
+  mode "640"
   notifies :run, "execute[chef-server-reconfigure]"
 end
 
@@ -101,7 +101,7 @@ template "/etc/cron.daily/chef-server-backup" do
   source "server-backup.cron.erb"
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end
 
 munin_plugin "chef_status"

--- a/cookbooks/civicrm/metadata.rb
+++ b/cookbooks/civicrm/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures CiviCRM"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "wordpress"

--- a/cookbooks/civicrm/recipes/default.rb
+++ b/cookbooks/civicrm/recipes/default.rb
@@ -60,13 +60,13 @@ wordpress_plugin "contact-form-7" do
   site "join.osmfoundation.org"
 end
 
-civicrm_version = node[:civicrm][:version]
+civicrm_version = node["civicrm"]["version"]
 civicrm_directory = "/srv/join.osmfoundation.org/wp-content/plugins/civicrm"
 
 directory "/opt/civicrm-#{civicrm_version}" do
   owner "wordpress"
   group "wordpress"
-  mode 0o755
+  mode "755"
 end
 
 remote_file "/var/cache/chef/civicrm-#{civicrm_version}-wordpress.zip" do
@@ -74,7 +74,7 @@ remote_file "/var/cache/chef/civicrm-#{civicrm_version}-wordpress.zip" do
   source "https://download.civicrm.org/civicrm-#{civicrm_version}-wordpress.zip"
   owner "wordpress"
   group "wordpress"
-  mode 0o644
+  mode "644"
   backup false
 end
 
@@ -83,7 +83,7 @@ remote_file "/var/cache/chef/civicrm-#{civicrm_version}-l10n.tar.gz" do
   source "https://download.civicrm.org/civicrm-#{civicrm_version}-l10n.tar.gz"
   owner "wordpress"
   group "wordpress"
-  mode 0o644
+  mode "644"
   backup false
 end
 
@@ -117,7 +117,7 @@ end
 directory "/srv/join.osmfoundation.org/wp-content/plugins/files" do
   owner "www-data"
   group "www-data"
-  mode 0o755
+  mode "755"
 end
 
 extensions_directory = "/srv/join.osmfoundation.org/wp-content/plugins/civicrm-extensions"
@@ -125,10 +125,10 @@ extensions_directory = "/srv/join.osmfoundation.org/wp-content/plugins/civicrm-e
 directory extensions_directory do
   owner "wordpress"
   group "wordpress"
-  mode 0o755
+  mode "755"
 end
 
-node[:civicrm][:extensions].each_value do |details|
+node["civicrm"]["extensions"].each_value do |details|
   git "#{extensions_directory}/#{details[:name]}" do
     action :sync
     repository details[:repository]
@@ -161,7 +161,7 @@ end
 file "#{civicrm_directory}/civicrm.settings.php" do
   owner "wordpress"
   group "wordpress"
-  mode 0o644
+  mode "644"
   content settings
 end
 
@@ -169,7 +169,7 @@ template "/etc/cron.d/osmf-crm" do
   source "cron.erb"
   owner "root"
   group "root"
-  mode 0o600
+  mode "600"
   variables :directory => civicrm_directory, :passwords => passwords
 end
 
@@ -177,6 +177,6 @@ template "/etc/cron.daily/osmf-crm-backup" do
   source "backup.cron.erb"
   owner "root"
   group "root"
-  mode 0o750
+  mode "750"
   variables :passwords => passwords
 end

--- a/cookbooks/clamav/metadata.rb
+++ b/cookbooks/clamav/metadata.rb
@@ -3,6 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures clamav"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
+
 version           "1.0.0"
 supports          "ubuntu"

--- a/cookbooks/clamav/recipes/default.rb
+++ b/cookbooks/clamav/recipes/default.rb
@@ -27,7 +27,7 @@ template "/etc/clamav-unofficial-sigs.conf.d/50-chef.conf" do
   source "clamav-unofficial-sigs.conf.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
 end
 
 service "clamav-daemon" do

--- a/cookbooks/db/metadata.rb
+++ b/cookbooks/db/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures database servers"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "postgresql"

--- a/cookbooks/db/recipes/backup.rb
+++ b/cookbooks/db/recipes/backup.rb
@@ -21,12 +21,12 @@ template "/usr/local/bin/backup-db" do
   source "backup-db.erb"
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end
 
 template "/etc/cron.d/backup-db" do
   source "backup.cron.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
 end

--- a/cookbooks/db/recipes/base.rb
+++ b/cookbooks/db/recipes/base.rb
@@ -25,13 +25,13 @@ passwords = data_bag_item("db", "passwords")
 wal_secrets = data_bag_item("db", "wal-secrets")
 
 postgresql_munin "openstreetmap" do
-  cluster node[:db][:cluster]
+  cluster node["db"]["cluster"]
   database "openstreetmap"
 end
 
 directory "/srv/www.openstreetmap.org" do
   group "rails"
-  mode 0o2775
+  mode "2775"
 end
 
 rails_port "www.openstreetmap.org" do
@@ -48,14 +48,14 @@ rails_port "www.openstreetmap.org" do
   gpx_dir "/store/rails/gpx"
 end
 
-db_version = node[:db][:cluster].split("/").first
+db_version = node["db"]["cluster"].split("/").first
 pg_config = "/usr/lib/postgresql/#{db_version}/bin/pg_config"
 function_directory = "/srv/www.openstreetmap.org/rails/db/functions/#{db_version}"
 
 directory function_directory do
   owner "rails"
   group "rails"
-  mode 0o755
+  mode "755"
 end
 
 execute function_directory do
@@ -88,6 +88,6 @@ template "/usr/local/bin/openstreetmap-wal-e" do
   source "wal-e.erb"
   owner "root"
   group "postgres"
-  mode 0o750
+  mode "750"
   variables :s3_key => wal_secrets["s3_key"]
 end

--- a/cookbooks/db/recipes/master.rb
+++ b/cookbooks/db/recipes/master.rb
@@ -22,65 +22,65 @@ include_recipe "db::base"
 passwords = data_bag_item("db", "passwords")
 
 postgresql_user "tomh" do
-  cluster node[:db][:cluster]
+  cluster node["db"]["cluster"]
   superuser true
 end
 
 postgresql_user "matt" do
-  cluster node[:db][:cluster]
+  cluster node["db"]["cluster"]
   superuser true
 end
 
 postgresql_user "openstreetmap" do
-  cluster node[:db][:cluster]
+  cluster node["db"]["cluster"]
   password passwords["openstreetmap"]
 end
 
 postgresql_user "rails" do
-  cluster node[:db][:cluster]
+  cluster node["db"]["cluster"]
   password passwords["rails"]
 end
 
 postgresql_user "planetdump" do
-  cluster node[:db][:cluster]
+  cluster node["db"]["cluster"]
   password passwords["planetdump"]
 end
 
 postgresql_user "planetdiff" do
-  cluster node[:db][:cluster]
+  cluster node["db"]["cluster"]
   password passwords["planetdiff"]
 end
 
 postgresql_user "backup" do
-  cluster node[:db][:cluster]
+  cluster node["db"]["cluster"]
   password passwords["backup"]
 end
 
 postgresql_user "gpximport" do
-  cluster node[:db][:cluster]
+  cluster node["db"]["cluster"]
   password passwords["gpximport"]
 end
 
 postgresql_user "munin" do
-  cluster node[:db][:cluster]
+  cluster node["db"]["cluster"]
   password passwords["munin"]
 end
 
 postgresql_user "replication" do
-  cluster node[:db][:cluster]
+  cluster node["db"]["cluster"]
   password passwords["replication"]
   replication true
 end
 
 postgresql_database "openstreetmap" do
-  cluster node[:db][:cluster]
+  cluster node["db"]["cluster"]
   owner "openstreetmap"
 end
 
 postgresql_extension "btree_gist" do
-  cluster node[:db][:cluster]
+  cluster node["db"]["cluster"]
   database "openstreetmap"
-  only_if { node[:postgresql][:clusters][node[:db][:cluster]] && node[:postgresql][:clusters][node[:db][:cluster]][:version] >= 9.0 }
+  only_if { node["postgresql"]["clusters"][node["db"]["cluster"]] && node["postgresql"]["clusters"][node["db"]["cluster"]]["version"] >= 9.0 }
 end
 
 file "/etc/cron.daily/rails-db" do

--- a/cookbooks/dev/metadata.rb
+++ b/cookbooks/dev/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures dev services"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "apache"

--- a/cookbooks/devices/metadata.rb
+++ b/cookbooks/devices/metadata.rb
@@ -3,6 +3,5 @@ maintainer       "Tom Hughes"
 maintainer_email "tom@compton.nu"
 license          "Apache-2.0"
 description      "Configures devices"
-long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version          "0.1"
 supports         "ubuntu"

--- a/cookbooks/devices/recipes/default.rb
+++ b/cookbooks/devices/recipes/default.rb
@@ -20,7 +20,7 @@
 cookbook_file "/usr/local/bin/fixeep-82574_83.sh" do
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end
 
 execute "udevadm-trigger" do
@@ -32,6 +32,6 @@ template "/etc/udev/rules.d/99-chef.rules" do
   source "udev.rules.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
   notifies :run, "execute[udevadm-trigger]"
 end

--- a/cookbooks/dhcpd/metadata.rb
+++ b/cookbooks/dhcpd/metadata.rb
@@ -3,7 +3,7 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Configures dhcpd"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
+
 version           "1.0.0"
 supports          "ubuntu"
 depends           "networking"

--- a/cookbooks/dhcpd/recipes/default.rb
+++ b/cookbooks/dhcpd/recipes/default.rb
@@ -21,13 +21,13 @@ include_recipe "networking"
 
 package "isc-dhcp-server"
 
-domain = "#{node[:networking][:roles][:external][:zone]}.openstreetmap.org"
+domain = "#{node['networking']['roles']['external']['zone']}.openstreetmap.org"
 
 template "/etc/dhcp/dhcpd.conf" do
   source "dhcpd.conf.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
   variables :domain => domain
 end
 

--- a/cookbooks/dmca/metadata.rb
+++ b/cookbooks/dmca/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Configure DMCA form"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "apache"

--- a/cookbooks/dmca/recipes/default.rb
+++ b/cookbooks/dmca/recipes/default.rb
@@ -24,14 +24,14 @@ apache_module "php7.2"
 directory "/srv/dmca.openstreetmap.org" do
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end
 
 remote_directory "/srv/dmca.openstreetmap.org/html" do
   source "html"
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
   files_owner "root"
   files_group "root"
   files_mode 0o644

--- a/cookbooks/dns/metadata.rb
+++ b/cookbooks/dns/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Configure DNS management"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "git"

--- a/cookbooks/dns/recipes/default.rb
+++ b/cookbooks/dns/recipes/default.rb
@@ -39,14 +39,14 @@ package %w[
 directory "/srv/dns.openstreetmap.org" do
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end
 
 remote_directory "/srv/dns.openstreetmap.org/html" do
   source "html"
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
   files_owner "root"
   files_group "root"
   files_mode 0o644
@@ -61,7 +61,7 @@ Dir.glob("/var/lib/dns/json/*.json").each do |kmlfile|
     source "zone.html.erb"
     owner "root"
     group "root"
-    mode 0o644
+    mode "644"
     variables :zone => zone
   end
 
@@ -72,7 +72,7 @@ template "/srv/dns.openstreetmap.org/html/index.html" do
   source "index.html.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
   variables :zones => zones
 end
 
@@ -91,7 +91,7 @@ template "/usr/local/bin/dns-update" do
   source "dns-update.erb"
   owner "root"
   group "git"
-  mode 0o750
+  mode "750"
   variables :passwords => passwords, :geoservers => geoservers
 end
 
@@ -105,22 +105,22 @@ end
 directory "/var/lib/dns" do
   owner "git"
   group "git"
-  mode 0o2775
+  mode "2775"
   notifies :run, "execute[dns-update]"
 end
 
-cookbook_file "#{node[:dns][:repository]}/hooks/post-receive" do
+cookbook_file "#{node['dns']['repository']}/hooks/post-receive" do
   source "post-receive"
   owner "git"
   group "git"
-  mode 0o750
+  mode "750"
 end
 
 template "/usr/local/bin/dns-check" do
   source "dns-check.erb"
   owner "root"
   group "git"
-  mode 0o750
+  mode "750"
   variables :passwords => passwords, :geoservers => geoservers
 end
 
@@ -128,5 +128,5 @@ template "/etc/cron.d/dns" do
   source "cron.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
 end

--- a/cookbooks/donate/metadata.rb
+++ b/cookbooks/donate/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures Donate Site"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "apache"

--- a/cookbooks/donate/recipes/default.rb
+++ b/cookbooks/donate/recipes/default.rb
@@ -48,7 +48,7 @@ end
 directory "/srv/donate.openstreetmap.org" do
   owner "donate"
   group "donate"
-  mode 0o755
+  mode "755"
 end
 
 git "/srv/donate.openstreetmap.org" do
@@ -61,14 +61,14 @@ end
 directory "/srv/donate.openstreetmap.org/data" do
   owner "donate"
   group "donate"
-  mode 0o755
+  mode "755"
 end
 
 template "/srv/donate.openstreetmap.org/scripts/db-connect.inc.php" do
   source "db-connect.inc.php.erb"
   owner "root"
   group "donate"
-  mode 0o644
+  mode "644"
   variables :passwords => passwords
 end
 
@@ -86,7 +86,7 @@ template "/etc/cron.d/osmf-donate" do
   source "cron.erb"
   owner "root"
   group "root"
-  mode 0o600
+  mode "600"
   variables :passwords => passwords
 end
 
@@ -94,6 +94,6 @@ template "/etc/cron.daily/osmf-donate-backup" do
   source "backup.cron.erb"
   owner "root"
   group "root"
-  mode 0o750
+  mode "750"
   variables :passwords => passwords
 end

--- a/cookbooks/elasticsearch/attributes/default.rb
+++ b/cookbooks/elasticsearch/attributes/default.rb
@@ -4,4 +4,4 @@ default[:elasticsearch][:cluster][:routing][:allocation][:disk][:watermark][:hig
 default[:elasticsearch][:cluster][:routing][:allocation][:disk][:watermark][:flood_stage] = "95%"
 default[:elasticsearch][:path][:data] = "/var/lib/elasticsearch"
 
-default[:apt][:sources] |= ["elasticsearch#{node[:elasticsearch][:version]}"]
+default[:apt][:sources] |= ["elasticsearch#{node['elasticsearch']['version']}"]

--- a/cookbooks/elasticsearch/metadata.rb
+++ b/cookbooks/elasticsearch/metadata.rb
@@ -3,6 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures a elasticsearch server"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
+
 version           "1.0.0"
 supports          "ubuntu"

--- a/cookbooks/elasticsearch/recipes/default.rb
+++ b/cookbooks/elasticsearch/recipes/default.rb
@@ -26,7 +26,7 @@ template "/etc/elasticsearch/elasticsearch.yml" do
   source "elasticsearch.yml.erb"
   user "root"
   group "root"
-  mode 0o644
+  mode "644"
   notifies :restart, "service[elasticsearch]"
 end
 

--- a/cookbooks/exim/metadata.rb
+++ b/cookbooks/exim/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures exim"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "networking"

--- a/cookbooks/fail2ban/metadata.rb
+++ b/cookbooks/fail2ban/metadata.rb
@@ -3,6 +3,5 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Configures fail2ban"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"

--- a/cookbooks/fail2ban/recipes/default.rb
+++ b/cookbooks/fail2ban/recipes/default.rb
@@ -23,7 +23,7 @@ template "/etc/fail2ban/jail.d/00-default.conf" do
   source "jail.default.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
   notifies :reload, "service[fail2ban]"
 end
 

--- a/cookbooks/fail2ban/resources/filter.rb
+++ b/cookbooks/fail2ban/resources/filter.rb
@@ -30,7 +30,7 @@ action :create do
       source new_resource.source
       owner "root"
       group "root"
-      mode 0o644
+      mode "644"
     end
   else
     template "/etc/fail2ban/filter.d/#{new_resource.filter}.conf" do
@@ -38,7 +38,7 @@ action :create do
       source "filter.erb"
       owner "root"
       group "root"
-      mode 0o644
+      mode "644"
       variables :failregex => new_resource.failregex,
                 :ignoreregex => new_resource.ignoreregex
     end

--- a/cookbooks/fail2ban/resources/jail.rb
+++ b/cookbooks/fail2ban/resources/jail.rb
@@ -33,7 +33,7 @@ action :create do
     source "jail.erb"
     owner "root"
     group "root"
-    mode 0o644
+    mode "644"
     variables :name => new_resource.jail,
               :filter => new_resource.filter,
               :logpath => new_resource.logpath,

--- a/cookbooks/forum/metadata.rb
+++ b/cookbooks/forum/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures a roundup server"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "apache"

--- a/cookbooks/forum/recipes/default.rb
+++ b/cookbooks/forum/recipes/default.rb
@@ -45,7 +45,7 @@ end
 directory "/srv/forum.openstreetmap.org" do
   owner "forum"
   group "forum"
-  mode 0o755
+  mode "755"
 end
 
 git "/srv/forum.openstreetmap.org/html/" do
@@ -63,7 +63,7 @@ remote_file "/var/cache/chef/air3_v0.8.zip" do
   source "https://fluxbb.org/resources/styles/air3/releases/0.8/air3_v0.8.zip"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
   backup false
 end
 
@@ -79,20 +79,20 @@ end
 directory "/srv/forum.openstreetmap.org/html/cache/" do
   owner "www-data"
   group "www-data"
-  mode 0o755
+  mode "755"
 end
 
 directory "/srv/forum.openstreetmap.org/html/img/avatars/" do
   owner "www-data"
   group "www-data"
-  mode 0o755
+  mode "755"
 end
 
 template "/srv/forum.openstreetmap.org/html/config.php" do
   source "config.php.erb"
   owner "forum"
   group "www-data"
-  mode 0o440
+  mode "440"
   variables :passwords => passwords
 end
 
@@ -108,6 +108,6 @@ template "/etc/cron.daily/forum-backup" do
   source "backup.cron.erb"
   owner "root"
   group "root"
-  mode 0o750
+  mode "750"
   variables :passwords => passwords
 end

--- a/cookbooks/foundation/metadata.rb
+++ b/cookbooks/foundation/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures foundation services"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "apache"

--- a/cookbooks/foundation/recipes/board.rb
+++ b/cookbooks/foundation/recipes/board.rb
@@ -39,7 +39,7 @@ mediawiki_site "board.osmfoundation.org" do
 end
 
 cookbook_file "/srv/board.osmfoundation.org/Wiki.png" do
-  owner node[:mediawiki][:user]
-  group node[:mediawiki][:group]
-  mode 0o644
+  owner node["mediawiki"]["user"]
+  group node["mediawiki"]["group"]
+  mode "644"
 end

--- a/cookbooks/foundation/recipes/dwg.rb
+++ b/cookbooks/foundation/recipes/dwg.rb
@@ -39,7 +39,7 @@ mediawiki_site "dwg.osmfoundation.org" do
 end
 
 cookbook_file "/srv/dwg.osmfoundation.org/Wiki.png" do
-  owner node[:mediawiki][:user]
-  group node[:mediawiki][:group]
-  mode 0o644
+  owner node["mediawiki"]["user"]
+  group node["mediawiki"]["group"]
+  mode "644"
 end

--- a/cookbooks/foundation/recipes/mwg.rb
+++ b/cookbooks/foundation/recipes/mwg.rb
@@ -39,7 +39,7 @@ mediawiki_site "mwg.osmfoundation.org" do
 end
 
 cookbook_file "/srv/mwg.osmfoundation.org/Wiki.png" do
-  owner node[:mediawiki][:user]
-  group node[:mediawiki][:group]
-  mode 0o644
+  owner node["mediawiki"]["user"]
+  group node["mediawiki"]["group"]
+  mode "644"
 end

--- a/cookbooks/foundation/recipes/owg.rb
+++ b/cookbooks/foundation/recipes/owg.rb
@@ -37,7 +37,7 @@ git "/srv/operations.osmfoundation.org" do
 end
 
 directory "/srv/operations.osmfoundation.org/_site" do
-  mode 0o755
+  mode "755"
   owner "nobody"
   group "nogroup"
 end

--- a/cookbooks/foundation/recipes/wiki.rb
+++ b/cookbooks/foundation/recipes/wiki.rb
@@ -55,7 +55,7 @@ mediawiki_skin "OSMFoundation" do
 end
 
 cookbook_file "/srv/wiki.osmfoundation.org/Wiki.png" do
-  owner node[:mediawiki][:user]
-  group node[:mediawiki][:group]
-  mode 0o644
+  owner node["mediawiki"]["user"]
+  group node["mediawiki"]["group"]
+  mode "644"
 end

--- a/cookbooks/ftp/metadata.rb
+++ b/cookbooks/ftp/metadata.rb
@@ -3,7 +3,6 @@ maintainer       "Grant Slater"
 maintainer_email "chef@firefishy.com"
 license          "Apache-2.0"
 description      "Installs/Configures ftp daemon"
-long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version          "0.1"
 supports         "ubuntu"
 depends          "networking"

--- a/cookbooks/ftp/recipes/default.rb
+++ b/cookbooks/ftp/recipes/default.rb
@@ -26,14 +26,14 @@ template "/etc/vsftpd.conf" do
   source "vsftpd.conf.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
 end
 
 template "/etc/pam.d/vsftpd" do
   source "pam-vsftpd.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
 end
 
 service "vsftpd" do

--- a/cookbooks/geodns/metadata.rb
+++ b/cookbooks/geodns/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures a geographic DNS server"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "systemd"

--- a/cookbooks/geodns/recipes/default.rb
+++ b/cookbooks/geodns/recipes/default.rb
@@ -32,14 +32,14 @@ end
 directory "/etc/gdnsd/config.d" do
   owner "nobody"
   group "nogroup"
-  mode 0o755
+  mode "755"
 end
 
 template "/etc/gdnsd/config" do
   source "config.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
   notifies :restart, "service[gdnsd]"
 end
 
@@ -47,7 +47,7 @@ template "/etc/gdnsd/zones/geo.openstreetmap.org" do
   source "geo.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
   notifies :restart, "service[gdnsd]"
 end
 

--- a/cookbooks/git/metadata.rb
+++ b/cookbooks/git/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures git"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "apache"

--- a/cookbooks/git/recipes/server.rb
+++ b/cookbooks/git/recipes/server.rb
@@ -19,32 +19,32 @@
 
 include_recipe "networking"
 
-git_directory = node[:git][:directory]
+git_directory = node["git"]["directory"]
 
 directory git_directory do
   owner "root"
   group "root"
-  mode 0o775
+  mode "775"
 end
 
 directory "#{git_directory}/public" do
-  owner node[:git][:public_user]
-  group node[:git][:public_group]
-  mode 0o2775
+  owner node["git"]["public_user"]
+  group node["git"]["public_group"]
+  mode "2775"
 end
 
 directory "#{git_directory}/private" do
-  owner node[:git][:private_user]
-  group node[:git][:private_group]
-  mode 0o2775
+  owner node["git"]["private_user"]
+  group node["git"]["private_group"]
+  mode "2775"
 end
 
 Dir.glob("#{git_directory}/*/*.git").each do |repository|
   template "#{repository}/hooks/post-update" do
     source "post-update.erb"
     owner "root"
-    group node[:git][:group]
-    mode 0o755
+    group node["git"]["group"]
+    mode "755"
   end
 end
 
@@ -52,5 +52,5 @@ template "/etc/cron.daily/git-backup" do
   source "backup.cron.erb"
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end

--- a/cookbooks/git/recipes/web.rb
+++ b/cookbooks/git/recipes/web.rb
@@ -23,40 +23,40 @@ package "gitweb"
 
 apache_module "rewrite"
 
-git_site = node[:git][:host]
+git_site = node["git"]["host"]
 
 template "/etc/gitweb.conf" do
   source "gitweb.conf.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
 end
 
 directory "/srv/#{git_site}" do
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end
 
 template "/srv/#{git_site}/robots.txt" do
   source "robots.txt.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
 end
 
 ssl_certificate git_site do
-  domains [git_site] + Array(node[:git][:aliases])
+  domains [git_site] + Array(node["git"]["aliases"])
   notifies :reload, "service[apache2]"
 end
 
-private_allowed = search(:node, node[:git][:private_nodes]).collect do |n|
+private_allowed = search(:node, node["git"]["private_nodes"]).collect do |n|
   n.ipaddresses(:role => :external)
 end.flatten
 
 apache_site git_site do
   template "apache.erb"
   directory "/srv/#{git_site}"
-  variables :aliases => Array(node[:git][:aliases]),
+  variables :aliases => Array(node["git"]["aliases"]),
             :private_allowed => private_allowed
 end

--- a/cookbooks/gps-tile/metadata.rb
+++ b/cookbooks/gps-tile/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Configures a GPS tile server"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "apache"

--- a/cookbooks/gps-tile/recipes/default.rb
+++ b/cookbooks/gps-tile/recipes/default.rb
@@ -35,7 +35,7 @@ package %w[
 directory "/srv/gps-tile.openstreetmap.org" do
   owner "gpstile"
   group "gpstile"
-  mode 0o755
+  mode "755"
 end
 
 git "/srv/gps-tile.openstreetmap.org/import" do
@@ -105,7 +105,7 @@ remote_directory "/srv/gps-tile.openstreetmap.org/html" do
   source "html"
   owner "gpstile"
   group "gpstile"
-  mode 0o755
+  mode "755"
   files_owner "gpstile"
   files_group "gpstile"
   files_mode 0o644

--- a/cookbooks/hardware/attributes/default.rb
+++ b/cookbooks/hardware/attributes/default.rb
@@ -2,39 +2,39 @@ default[:hardware][:modules] = %w[lp]
 default[:hardware][:grub][:cmdline] = %w[nomodeset]
 default[:hardware][:sensors] = {}
 
-if node[:dmi] && node[:dmi][:system]
-  case node[:dmi][:system][:manufacturer]
+if node["dmi"] && node["dmi"]["system"]
+  case node["dmi"]["system"]["manufacturer"]
   when "HP"
     default[:apt][:sources] |= ["management-component-pack"]
 
-    case node[:dmi][:system][:product_name]
+    case node["dmi"]["system"]["product_name"]
     when "ProLiant DL360 G6", "ProLiant DL360 G7", "ProLiant SE326M1R2"
       default[:hardware][:sensors][:"power_meter-*"][:power][:power1] = { :ignore => true }
     end
   end
 end
 
-if Chef::Util.compare_versions(node[:kernel][:release], [3, 3]).negative?
+if Chef::Util.compare_versions(node["kernel"]["release"], [3, 3]).negative?
   default[:hardware][:modules] |= ["microcode"]
 
-  if node[:cpu][:"0"][:vendor_id] == "GenuineIntel"
+  if node["cpu"]["0"]["vendor_id"] == "GenuineIntel"
     default[:hardware][:modules] |= ["coretemp"]
   end
 end
 
-if node[:kernel] && node[:kernel][:modules]
-  raidmods = node[:kernel][:modules].keys & %w[cciss hpsa mptsas mpt2sas mpt3sas megaraid_mm megaraid_sas aacraid]
+if node["kernel"] && node["kernel"]["modules"]
+  raidmods = node["kernel"]["modules"].keys & %w[cciss hpsa mptsas mpt2sas mpt3sas megaraid_mm megaraid_sas aacraid]
 
   default[:apt][:sources] |= ["hwraid"] unless raidmods.empty?
 end
 
-if node[:kernel][:modules].include?("ipmi_si")
+if node["kernel"]["modules"].include?("ipmi_si")
   default[:hardware][:modules] |= ["ipmi_devintf"]
 end
 
 if File.exist?("/proc/xen")
   default[:hardware][:watchdog] = "xen_wdt"
-elsif node[:kernel][:modules].include?("i6300esb")
+elsif node["kernel"]["modules"].include?("i6300esb")
   default[:hardware][:watchdog] = "none"
 end
 

--- a/cookbooks/hardware/metadata.rb
+++ b/cookbooks/hardware/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Configures hardware"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "apt"

--- a/cookbooks/hardware/recipes/default.rb
+++ b/cookbooks/hardware/recipes/default.rb
@@ -24,21 +24,21 @@ ohai_plugin "hardware" do
   template "ohai.rb.erb"
 end
 
-case node[:cpu][:"0"][:vendor_id]
+case node["cpu"]["0"]["vendor_id"]
 when "GenuineIntel"
   package "intel-microcode"
 when "AuthenticAMD"
   package "amd64-microcode"
 end
 
-if node[:dmi] && node[:dmi][:system]
-  case node[:dmi][:system][:manufacturer]
+if node["dmi"] && node["dmi"]["system"]
+  case node["dmi"]["system"]["manufacturer"]
   when "empty"
-    manufacturer = node[:dmi][:base_board][:manufacturer]
-    product = node[:dmi][:base_board][:product_name]
+    manufacturer = node["dmi"]["base_board"]["manufacturer"]
+    product = node["dmi"]["base_board"]["product_name"]
   else
-    manufacturer = node[:dmi][:system][:manufacturer]
-    product = node[:dmi][:system][:product_name]
+    manufacturer = node["dmi"]["system"]["manufacturer"]
+    product = node["dmi"]["system"]["product_name"]
   end
 else
   manufacturer = "Unknown"
@@ -47,7 +47,7 @@ end
 
 units = []
 
-if node[:roles].include?("bytemark") || node[:roles].include?("exonetric")
+if node["roles"].include?("bytemark") || node["roles"].include?("exonetric")
   units << "0"
 end
 
@@ -103,8 +103,8 @@ end
 # work (e.g: https://github.com/openstreetmap/operations/issues/45) then
 # ensure that we have the package installed. the grub template will
 # make sure that this is the default on boot.
-if node[:hardware][:grub][:kernel]
-  kernel_version = node[:hardware][:grub][:kernel]
+if node["hardware"]["grub"]["kernel"]
+  kernel_version = node["hardware"]["grub"]["kernel"]
 
   package "linux-image-#{kernel_version}-generic"
   package "linux-image-extra-#{kernel_version}-generic"
@@ -128,7 +128,7 @@ if File.exist?("/etc/default/grub")
     source "grub.erb"
     owner "root"
     group "root"
-    mode 0o644
+    mode "644"
     variables :units => units, :entry => grub_entry
     notifies :run, "execute[update-grub]"
   end
@@ -145,7 +145,7 @@ template "/etc/initramfs-tools/conf.d/mdadm" do
   source "initramfs-mdadm.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
   notifies :run, "execute[update-initramfs]"
 end
 
@@ -154,7 +154,7 @@ service "haveged" do
   action [:enable, :start]
 end
 
-package "ipmitool" if node[:kernel][:modules].include?("ipmi_si")
+package "ipmitool" if node["kernel"]["modules"].include?("ipmi_si")
 
 package "irqbalance"
 
@@ -162,7 +162,7 @@ template "/etc/default/irqbalance" do
   source "irqbalance.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
 end
 
 service "irqbalance" do
@@ -181,7 +181,7 @@ end
 tools_packages = []
 status_packages = {}
 
-node[:kernel][:modules].each_key do |modname|
+node["kernel"]["modules"].each_key do |modname|
   case modname
   when "cciss"
     tools_packages << "ssacli"
@@ -209,7 +209,7 @@ node[:kernel][:modules].each_key do |modname|
   end
 end
 
-node[:block_device].each do |name, attributes|
+node["block_device"].each do |name, attributes|
   next unless attributes[:vendor] == "HP" && attributes[:model] == "LOGICAL VOLUME"
 
   if name =~ /^cciss!(c[0-9]+)d[0-9]+$/
@@ -252,7 +252,7 @@ if status_packages.include?("cciss-vol-status")
     source "cciss-vol-statusd.erb"
     owner "root"
     group "root"
-    mode 0o755
+    mode "755"
     notifies :restart, "service[cciss-vol-statusd]"
   end
 
@@ -275,7 +275,7 @@ end
       source "raid.default.erb"
       owner "root"
       group "root"
-      mode 0o644
+      mode "644"
       variables :devices => status_packages[status_package]
     end
 
@@ -295,16 +295,16 @@ end
   end
 end
 
-disks = if node[:hardware][:disk]
-          node[:hardware][:disk][:disks]
+disks = if node["hardware"]["disk"]
+          node["hardware"]["disk"]["disks"]
         else
           []
         end
 
 intel_ssds = disks.select { |d| d[:vendor] == "INTEL" && d[:model] =~ /^SSD/ }
 
-nvmes = if node[:hardware][:pci]
-          node[:hardware][:pci].values.select { |pci| pci[:driver] == "nvme" }
+nvmes = if node["hardware"]["pci"]
+          node["hardware"]["pci"].values.select { |pci| pci[:driver] == "nvme" }
         else
           []
         end
@@ -338,14 +338,14 @@ disks = disks.map do |disk|
   next if disk[:state] == "spun_down" || %w[unconfigured failed].any?(disk[:status])
 
   if disk[:smart_device]
-    controller = node[:hardware][:disk][:controllers][disk[:controller]]
+    controller = node["hardware"]["disk"]["controllers"][disk[:controller]]
 
     if controller && controller[:device]
       device = controller[:device].sub("/dev/", "")
       smart = disk[:smart_device]
 
       if device.start_with?("cciss/") && smart =~ /^cciss,(\d+)$/
-        array = node[:hardware][:disk][:arrays][disk[:arrays].first]
+        array = node["hardware"]["disk"]["arrays"][disk[:arrays].first]
         munin = "cciss-3#{array[:wwn]}-#{Regexp.last_match(1)}"
       elsif smart =~ /^.*,(\d+)$/
         munin = "#{device}-#{Regexp.last_match(1)}"
@@ -380,14 +380,14 @@ if disks.count.positive?
     source "smartd-mailer.erb"
     owner "root"
     group "root"
-    mode 0o755
+    mode "755"
   end
 
   template "/etc/smartd.conf" do
     source "smartd.conf.erb"
     owner "root"
     group "root"
-    mode 0o644
+    mode "644"
     variables :disks => disks
   end
 
@@ -395,7 +395,7 @@ if disks.count.positive?
     source "smartmontools.erb"
     owner "root"
     group "root"
-    mode 0o644
+    mode "644"
   end
 
   service "smartd" do
@@ -455,7 +455,7 @@ if File.exist?("/etc/mdadm/mdadm.conf")
   file "/etc/mdadm/mdadm.conf" do
     owner "root"
     group "root"
-    mode 0o644
+    mode "644"
     content mdadm_conf
   end
 
@@ -469,7 +469,7 @@ template "/etc/modules" do
   source "modules.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
 end
 
 service "kmod" do
@@ -477,15 +477,15 @@ service "kmod" do
   subscribes :start, "template[/etc/modules]"
 end
 
-if node[:hardware][:watchdog]
+if node["hardware"]["watchdog"]
   package "watchdog"
 
   template "/etc/default/watchdog" do
     source "watchdog.erb"
     owner "root"
     group "root"
-    mode 0o644
-    variables :module => node[:hardware][:watchdog]
+    mode "644"
+    variables :module => node["hardware"]["watchdog"]
   end
 
   service "watchdog" do
@@ -511,12 +511,12 @@ unless Dir.glob("/sys/class/hwmon/hwmon*").empty?
             end
 
     if temps.first == 1
-      node.default[:hardware][:sensors][chip][:temps][:temp1][:label] = "CPU #{cpu}"
+      node.default["hardware"]["sensors"][chip]["temps"]["temp1"][:label] = "CPU #{cpu}"
       temps.shift
     end
 
     temps.each_with_index do |temp, index|
-      node.default[:hardware][:sensors][chip][:temps]["temp#{temp}"][:label] = "CPU #{cpu} Core #{index}"
+      node.default["hardware"]["sensors"][chip]["temps"]["temp#{temp}"][:label] = "CPU #{cpu} Core #{index}"
     end
   end
 
@@ -531,16 +531,16 @@ unless Dir.glob("/sys/class/hwmon/hwmon*").empty?
     source "sensors.conf.erb"
     owner "root"
     group "root"
-    mode 0o644
+    mode "644"
     notifies :run, "execute[/etc/sensors.d/chef.conf]"
   end
 end
 
-if node[:hardware][:shm_size]
+if node["hardware"]["shm_size"]
   mount "/dev/shm" do
     action [:mount, :enable]
     device "tmpfs"
     fstype "tmpfs"
-    options "rw,nosuid,nodev,size=#{node[:hardware][:shm_size]}"
+    options "rw,nosuid,nodev,size=#{node['hardware']['shm_size']}"
   end
 end

--- a/cookbooks/hot/metadata.rb
+++ b/cookbooks/hot/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Configures hot web site"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "apache"

--- a/cookbooks/imagery/metadata.rb
+++ b/cookbooks/imagery/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures imagery"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "nginx"

--- a/cookbooks/imagery/recipes/default.rb
+++ b/cookbooks/imagery/recipes/default.rb
@@ -51,21 +51,21 @@ package %w[
 directory "/srv/imagery/mapserver" do
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
   recursive true
 end
 
 directory "/srv/imagery/common" do
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
   recursive true
 end
 
 directory "/srv/imagery/common/ostn02-ntv2-data" do
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end
 
 remote_file "#{Chef::Config[:file_cache_path]}/ostn02-ntv2-data.zip" do

--- a/cookbooks/imagery/resources/layer.rb
+++ b/cookbooks/imagery/resources/layer.rb
@@ -44,7 +44,7 @@ action :create do
   file "/srv/imagery/layers/#{new_resource.site}/#{new_resource.layer}.yml" do
     owner "root"
     group "root"
-    mode 0o644
+    mode "644"
     content YAML.dump(:name => new_resource.layer,
                       :title => new_resource.title || new_resource.layer,
                       :url => "//{s}.#{new_resource.site}/layer/#{new_resource.layer}/{z}/{x}/{y}.png",
@@ -59,7 +59,7 @@ action :create do
     source "mapserver.map.erb"
     owner "root"
     group "root"
-    mode 0o644
+    mode "644"
     variables new_resource.to_hash
   end
 
@@ -76,7 +76,7 @@ action :create do
   directory "/srv/imagery/nginx/#{new_resource.site}" do
     owner "root"
     group "root"
-    mode 0o755
+    mode "755"
     recursive true
   end
 
@@ -85,7 +85,7 @@ action :create do
     source "nginx_imagery_layer_fragment.conf.erb"
     owner "root"
     group "root"
-    mode 0o644
+    mode "644"
     variables new_resource.to_hash
   end
 end

--- a/cookbooks/imagery/resources/site.rb
+++ b/cookbooks/imagery/resources/site.rb
@@ -30,20 +30,20 @@ action :create do
   directory "/srv/#{new_resource.site}" do
     user "root"
     group "root"
-    mode 0o755
+    mode "755"
   end
 
   directory "/srv/imagery/layers/#{new_resource.site}" do
     user "root"
     group "root"
-    mode 0o755
+    mode "755"
     recursive true
   end
 
   directory "/srv/imagery/overlays/#{new_resource.site}" do
     user "root"
     group "root"
-    mode 0o755
+    mode "755"
     recursive true
   end
 
@@ -51,7 +51,7 @@ action :create do
     source "index.html.erb"
     user "root"
     group "root"
-    mode 0o644
+    mode "644"
     variables :title => new_resource.title
   end
 
@@ -59,28 +59,28 @@ action :create do
     source "robots.txt"
     user "root"
     group "root"
-    mode 0o644
+    mode "644"
   end
 
   cookbook_file "/srv/#{new_resource.site}/imagery.css" do
     source "imagery.css"
     user "root"
     group "root"
-    mode 0o644
+    mode "644"
   end
 
   cookbook_file "/srv/#{new_resource.site}/clientaccesspolicy.xml" do
     source "clientaccesspolicy.xml"
     user "root"
     group "root"
-    mode 0o644
+    mode "644"
   end
 
   cookbook_file "/srv/#{new_resource.site}/crossdomain.xml" do
     source "crossdomain.xml"
     user "root"
     group "root"
-    mode 0o644
+    mode "644"
   end
 
   layers = Dir.glob("/srv/imagery/layers/#{new_resource.site}/*.yml").collect do |path|
@@ -91,7 +91,7 @@ action :create do
     source "imagery.js.erb"
     user "root"
     group "root"
-    mode 0o644
+    mode "644"
     variables :bbox => new_resource.bbox, :layers => layers
   end
 

--- a/cookbooks/incron/metadata.rb
+++ b/cookbooks/incron/metadata.rb
@@ -3,6 +3,5 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Configures incron"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"

--- a/cookbooks/incron/recipes/default.rb
+++ b/cookbooks/incron/recipes/default.rb
@@ -26,7 +26,7 @@ end
 
 incrontabs = {}
 
-node[:incron].each_value do |details|
+node["incron"].each_value do |details|
   user = details[:user]
   path = details[:path]
   mask = details[:events].join(",")
@@ -41,7 +41,7 @@ incrontabs.each do |user, lines|
   file "/var/spool/incron/#{user}" do
     owner user
     group "incron"
-    mode 0o600
+    mode "600"
     content lines.join("\n")
   end
 end

--- a/cookbooks/kibana/metadata.rb
+++ b/cookbooks/kibana/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures a kibana server"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "apache"

--- a/cookbooks/kibana/recipes/default.rb
+++ b/cookbooks/kibana/recipes/default.rb
@@ -23,7 +23,7 @@ include_recipe "apache"
 
 apache_module "proxy_http"
 
-version = node[:kibana][:version]
+version = node["kibana"]["version"]
 
 remote_file "#{Chef::Config[:file_cache_path]}/kibana-#{version}.tar.gz" do
   source "https://download.elastic.co/kibana/kibana/kibana-4.1.1-linux-x64.tar.gz"
@@ -33,7 +33,7 @@ end
 directory "/opt/kibana-#{version}" do
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end
 
 execute "unzip-kibana-#{version}" do
@@ -47,19 +47,19 @@ end
 directory "/etc/kibana" do
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end
 
 directory "/var/run/kibana" do
   owner "kibana"
   group "kibana"
-  mode 0o755
+  mode "755"
 end
 
 directory "/var/log/kibana" do
   owner "kibana"
   group "kibana"
-  mode 0o755
+  mode "755"
 end
 
 systemd_service "kibana@" do
@@ -75,7 +75,7 @@ systemd_service "kibana@" do
   restart "on-failure"
 end
 
-node[:kibana][:sites].each do |name, details|
+node["kibana"]["sites"].each do |name, details|
   file "/etc/kibana/#{name}.yml" do
     content YAML.dump(YAML.safe_load(File.read("/opt/kibana-#{version}/config/kibana.yml")).merge(
                         "port" => details[:port],
@@ -86,7 +86,7 @@ node[:kibana][:sites].each do |name, details|
                       ))
     owner "root"
     group "root"
-    mode 0o644
+    mode "644"
     notifies :restart, "service[kibana@#{name}]"
   end
 

--- a/cookbooks/letsencrypt/metadata.rb
+++ b/cookbooks/letsencrypt/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Support for letsencrypt certificates"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "apache"

--- a/cookbooks/letsencrypt/recipes/default.rb
+++ b/cookbooks/letsencrypt/recipes/default.rb
@@ -29,31 +29,31 @@ package %w[
 directory "/etc/letsencrypt" do
   owner "letsencrypt"
   group "letsencrypt"
-  mode 0o755
+  mode "755"
 end
 
 directory "/var/lib/letsencrypt" do
   owner "letsencrypt"
   group "letsencrypt"
-  mode 0o755
+  mode "755"
 end
 
 directory "/var/log/letsencrypt" do
   owner "letsencrypt"
   group "letsencrypt"
-  mode 0o700
+  mode "700"
 end
 
 directory "/srv/acme.openstreetmap.org" do
   owner "letsencrypt"
   group "letsencrypt"
-  mode 0o755
+  mode "755"
 end
 
 directory "/srv/acme.openstreetmap.org/html" do
   owner "letsencrypt"
   group "letsencrypt"
-  mode 0o755
+  mode "755"
 end
 
 ssl_certificate "acme.openstreetmap.org" do
@@ -69,46 +69,46 @@ end
 directory "/srv/acme.openstreetmap.org/config" do
   owner "letsencrypt"
   group "letsencrypt"
-  mode 0o755
+  mode "755"
 end
 
 directory "/srv/acme.openstreetmap.org/work" do
   owner "letsencrypt"
   group "letsencrypt"
-  mode 0o755
+  mode "755"
 end
 
 directory "/srv/acme.openstreetmap.org/logs" do
   owner "letsencrypt"
   group "letsencrypt"
-  mode 0o700
+  mode "700"
 end
 
 directory "/srv/acme.openstreetmap.org/.chef" do
   owner "letsencrypt"
   group "letsencrypt"
-  mode 0o2775
+  mode "2775"
 end
 
 file "/srv/acme.openstreetmap.org/.chef/client.pem" do
   content keys["letsencrypt"].join("\n")
   owner "letsencrypt"
   group "letsencrypt"
-  mode 0o660
+  mode "660"
 end
 
 cookbook_file "/srv/acme.openstreetmap.org/.chef/knife.rb" do
   source "knife.rb"
   owner "letsencrypt"
   group "letsencrypt"
-  mode 0o660
+  mode "660"
 end
 
 remote_directory "/srv/acme.openstreetmap.org/bin" do
   source "bin"
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
   files_owner "root"
   files_group "root"
   files_mode 0o755
@@ -117,7 +117,7 @@ end
 directory "/srv/acme.openstreetmap.org/requests" do
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end
 
 certificates = search(:node, "letsencrypt:certificates").each_with_object({}) do |n, c|
@@ -136,7 +136,7 @@ certificates.each do |name, details|
     source "request.erb"
     owner "root"
     group "letsencrypt"
-    mode 0o754
+    mode "754"
     variables details
   end
 
@@ -169,7 +169,7 @@ template "/srv/acme.openstreetmap.org/bin/check-certificates" do
   source "check-certificates.erb"
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
   variables :certificates => certificates
 end
 
@@ -177,5 +177,5 @@ template "/etc/cron.d/letsencrypt" do
   source "cron.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
 end

--- a/cookbooks/logstash/metadata.rb
+++ b/cookbooks/logstash/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures a elasticsearch server"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "networking"

--- a/cookbooks/logstash/recipes/default.rb
+++ b/cookbooks/logstash/recipes/default.rb
@@ -30,7 +30,7 @@ cookbook_file "/var/lib/logstash/beats.crt" do
   source "beats.crt"
   user "root"
   group "logstash"
-  mode 0o644
+  mode "644"
   notifies :restart, "service[logstash]"
 end
 
@@ -38,7 +38,7 @@ file "/var/lib/logstash/beats.key" do
   content keys["beats"].join("\n")
   user "root"
   group "logstash"
-  mode 0o640
+  mode "640"
   notifies :restart, "service[logstash]"
 end
 
@@ -46,19 +46,19 @@ template "/etc/logstash/conf.d/chef.conf" do
   source "logstash.conf.erb"
   user "root"
   group "root"
-  mode 0o644
+  mode "644"
   notifies :reload, "service[logstash]"
 end
 
 file "/etc/logrotate.d/logstash" do
-  mode 0o644
+  mode "644"
 end
 
 template "/etc/default/logstash" do
   source "logstash.default.erb"
   user "root"
   group "root"
-  mode 0o644
+  mode "644"
   notifies :restart, "service[logstash]"
 end
 
@@ -71,7 +71,7 @@ template "/etc/cron.daily/expire-logstash" do
   source "expire.erb"
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end
 
 forwarders = search(:node, "recipes:logstash\\:\\:forwarder") # ~FC010

--- a/cookbooks/logstash/recipes/forwarder.rb
+++ b/cookbooks/logstash/recipes/forwarder.rb
@@ -25,15 +25,15 @@ cookbook_file "/etc/filebeat/filebeat.crt" do
   source "beats.crt"
   user "root"
   group "root"
-  mode 0o600
+  mode "600"
   notifies :restart, "service[filebeat]"
 end
 
 file "/etc/filebeat/filebeat.yml" do
-  content YAML.dump(node[:logstash][:forwarder].to_hash)
+  content YAML.dump(node["logstash"]["forwarder"].to_hash)
   user "root"
   group "root"
-  mode 0o600
+  mode "600"
   notifies :restart, "service[filebeat]"
 end
 

--- a/cookbooks/mailman/metadata.rb
+++ b/cookbooks/mailman/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures mailman"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "apache"

--- a/cookbooks/mailman/recipes/default.rb
+++ b/cookbooks/mailman/recipes/default.rb
@@ -29,7 +29,7 @@ template "/etc/mailman/mm_cfg.py" do
   source "mm_cfg.py.erb"
   user "root"
   group "root"
-  mode 0o644
+  mode "644"
   notifies :restart, "service[mailman]"
 end
 
@@ -56,5 +56,5 @@ template "/etc/cron.daily/lists-backup" do
   source "backup.cron.erb"
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end

--- a/cookbooks/mediawiki/attributes/default.rb
+++ b/cookbooks/mediawiki/attributes/default.rb
@@ -1,5 +1,5 @@
 # Add the mediawiki APT source
-default[:apt][:sources] = node[:apt][:sources] | ["mediawiki"]
+default[:apt][:sources] = node["apt"]["sources"] | ["mediawiki"]
 
 # Default to enabling the "wiki" role
 default[:accounts][:users][:wiki][:status] = :role

--- a/cookbooks/mediawiki/metadata.rb
+++ b/cookbooks/mediawiki/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures mediawiki"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "memcached"

--- a/cookbooks/mediawiki/recipes/default.rb
+++ b/cookbooks/mediawiki/recipes/default.rb
@@ -74,7 +74,7 @@ template "/etc/mediawiki/parsoid/config.yaml" do
   source "parsoid-config.yaml.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
 end
 
 service "parsoid" do

--- a/cookbooks/mediawiki/resources/extension.rb
+++ b/cookbooks/mediawiki/resources/extension.rb
@@ -36,11 +36,11 @@ action :create do
     remote_directory extension_directory do
       cookbook "mediawiki"
       source new_resource.source
-      owner node[:mediawiki][:user]
-      group node[:mediawiki][:group]
-      mode 0o755
-      files_owner node[:mediawiki][:user]
-      files_group node[:mediawiki][:group]
+      owner node["mediawiki"]["user"]
+      group node["mediawiki"]["group"]
+      mode "755"
+      files_owner node["mediawiki"]["user"]
+      files_group node["mediawiki"]["group"]
       files_mode 0o755
     end
   else
@@ -58,8 +58,8 @@ action :create do
       repository extension_repository
       reference extension_reference
       enable_submodules true
-      user node[:mediawiki][:user]
-      group node[:mediawiki][:group]
+      user node["mediawiki"]["user"]
+      group node["mediawiki"]["group"]
       ignore_failure extension_repository.start_with?("git://github.com/wikimedia/mediawiki-extensions")
     end
   end
@@ -68,17 +68,17 @@ action :create do
     declare_resource :template, "#{mediawiki_directory}/LocalSettings.d/Ext-#{new_resource.extension}.inc.php" do
       cookbook new_resource.template_cookbook
       source new_resource.template
-      user node[:mediawiki][:user]
-      group node[:mediawiki][:group]
-      mode 0o664
+      user node["mediawiki"]["user"]
+      group node["mediawiki"]["group"]
+      mode "664"
       variables new_resource.variables
     end
   else
     file "#{mediawiki_directory}/LocalSettings.d/Ext-#{new_resource.extension}.inc.php" do
       content "<?php wfLoadExtension( '#{new_resource.extension}' );\n"
-      user node[:mediawiki][:user]
-      group node[:mediawiki][:group]
-      mode 0o664
+      user node["mediawiki"]["user"]
+      group node["mediawiki"]["group"]
+      mode "664"
     end
   end
 
@@ -86,8 +86,8 @@ action :create do
     action :nothing
     command "composer update --no-dev"
     cwd mediawiki_directory
-    user node[:mediawiki][:user]
-    group node[:mediawiki][:group]
+    user node["mediawiki"]["user"]
+    group node["mediawiki"]["group"]
     only_if { ::File.exist?("#{extension_directory}/composer.json") }
     subscribes :run, "git[#{extension_directory}]"
   end
@@ -106,7 +106,7 @@ end
 
 action_class do
   def site_directory
-    node[:mediawiki][:sites][new_resource.site][:directory]
+    node["mediawiki"]["sites"][new_resource.site]["directory"]
   end
 
   def mediawiki_directory
@@ -118,7 +118,7 @@ action_class do
   end
 
   def extension_version
-    new_resource.version || node[:mediawiki][:sites][new_resource.site][:version]
+    new_resource.version || node["mediawiki"]["sites"][new_resource.site]["version"]
   end
 
   def default_repository
@@ -130,7 +130,7 @@ def after_created
   if update_site
     notifies :update, "mediawiki_site[#{site}]"
   else
-    site_directory = node[:mediawiki][:sites][site][:directory]
+    site_directory = node["mediawiki"]["sites"][site]["directory"]
 
     notifies :create, "template[#{site_directory}/w/LocalSettings.php]"
     notifies :run, "execute[#{site_directory}/w/maintenance/update.php]"

--- a/cookbooks/mediawiki/resources/site.rb
+++ b/cookbooks/mediawiki/resources/site.rb
@@ -48,8 +48,8 @@ property :reload_apache, :kind_of => [TrueClass, FalseClass], :default => true
 action :create do
   node.normal_unless[:mediawiki][:sites][new_resource.site] = {}
 
-  node.normal[:mediawiki][:sites][new_resource.site][:directory] = site_directory
-  node.normal[:mediawiki][:sites][new_resource.site][:version] = new_resource.version
+  node.normal["mediawiki"]["sites"][new_resource.site][:directory] = site_directory
+  node.normal["mediawiki"]["sites"][new_resource.site][:version] = new_resource.version
 
   node.normal_unless[:mediawiki][:sites][new_resource.site][:wgSecretKey] = SecureRandom.base64(48)
 
@@ -75,8 +75,8 @@ action :create do
     # Use metanamespace as Site Name to ensure correct set namespace
     command "php maintenance/install.php --server '#{name}' --dbtype 'mysql' --dbname '#{new_resource.database_name}' --dbuser '#{new_resource.database_user}' --dbpass '#{new_resource.database_password}' --dbserver 'localhost' --scriptpath /w --pass '#{new_resource.admin_password}' '#{new_resource.metanamespace}' '#{new_resource.admin_user}'"
     cwd mediawiki_directory
-    user node[:mediawiki][:user]
-    group node[:mediawiki][:group]
+    user node["mediawiki"]["user"]
+    group node["mediawiki"]["group"]
     not_if do
       ::File.exist?("#{mediawiki_directory}/LocalSettings-install.php")
     end
@@ -87,20 +87,20 @@ action :create do
     action :nothing
     command "php maintenance/update.php --quick"
     cwd mediawiki_directory
-    user node[:mediawiki][:user]
-    group node[:mediawiki][:group]
+    user node["mediawiki"]["user"]
+    group node["mediawiki"]["group"]
   end
 
   declare_resource :directory, site_directory do
-    owner node[:mediawiki][:user]
-    group node[:mediawiki][:group]
-    mode 0o775
+    owner node["mediawiki"]["user"]
+    group node["mediawiki"]["group"]
+    mode "775"
   end
 
   declare_resource :directory, mediawiki_directory do
-    owner node[:mediawiki][:user]
-    group node[:mediawiki][:group]
-    mode 0o775
+    owner node["mediawiki"]["user"]
+    group node["mediawiki"]["group"]
+    mode "775"
   end
 
   mediawiki_reference = "REL#{new_resource.version}".tr(".", "_")
@@ -109,8 +109,8 @@ action :create do
     action :sync
     repository "https://gerrit.wikimedia.org/r/p/mediawiki/core.git"
     revision mediawiki_reference
-    user node[:mediawiki][:user]
-    group node[:mediawiki][:group]
+    user node["mediawiki"]["user"]
+    group node["mediawiki"]["group"]
     notifies :run, "execute[#{mediawiki_directory}/composer.json]", :immediately
     notifies :run, "execute[#{mediawiki_directory}/maintenance/install.php]", :immediately
     notifies :run, "execute[#{mediawiki_directory}/maintenance/update.php]"
@@ -120,16 +120,16 @@ action :create do
     action :nothing
     command "composer update --no-dev"
     cwd mediawiki_directory
-    user node[:mediawiki][:user]
-    group node[:mediawiki][:group]
+    user node["mediawiki"]["user"]
+    group node["mediawiki"]["group"]
   end
 
   template "#{mediawiki_directory}/composer.local.json" do
     cookbook "mediawiki"
     source "composer.local.json.erb"
-    owner node[:mediawiki][:user]
-    group node[:mediawiki][:group]
-    mode 0o664
+    owner node["mediawiki"]["user"]
+    group node["mediawiki"]["group"]
+    mode "664"
   end
 
   # Safety catch if git doesn't update but install.php hasn't run
@@ -145,28 +145,28 @@ action :create do
 
   declare_resource :directory, "#{mediawiki_directory}/images" do
     owner "www-data"
-    group node[:mediawiki][:group]
-    mode 0o775
+    group node["mediawiki"]["group"]
+    mode "775"
   end
 
   declare_resource :directory, "#{mediawiki_directory}/cache" do
     owner "www-data"
-    group node[:mediawiki][:group]
-    mode 0o775
+    group node["mediawiki"]["group"]
+    mode "775"
   end
 
   declare_resource :directory, "#{mediawiki_directory}/LocalSettings.d" do
-    user node[:mediawiki][:user]
-    group node[:mediawiki][:group]
-    mode 0o775
+    user node["mediawiki"]["user"]
+    group node["mediawiki"]["group"]
+    mode "775"
   end
 
   template "#{mediawiki_directory}/LocalSettings.php" do
     cookbook "mediawiki"
     source "LocalSettings.php.erb"
-    owner node[:mediawiki][:user]
-    group node[:mediawiki][:group]
-    mode 0o664
+    owner node["mediawiki"]["user"]
+    group node["mediawiki"]["group"]
+    mode "664"
     variables :name => new_resource.site,
               :directory => mediawiki_directory,
               :database_params => database_params,
@@ -179,9 +179,9 @@ action :create do
     source "mediawiki.cron.erb"
     owner "root"
     group "root"
-    mode 0o644
+    mode "644"
     variables :name => new_resource.site, :directory => site_directory,
-              :user => node[:mediawiki][:user]
+              :user => node["mediawiki"]["user"]
   end
 
   template "/etc/cron.daily/mediawiki-#{cron_name}-backup" do
@@ -189,7 +189,7 @@ action :create do
     source "mediawiki-backup.cron.erb"
     owner "root"
     group "root"
-    mode 0o700
+    mode "700"
     variables :name => new_resource.site,
               :directory => site_directory,
               :database_params => database_params
@@ -464,25 +464,25 @@ action :create do
 
   cookbook_file "#{site_directory}/cc-wiki.png" do
     cookbook "mediawiki"
-    owner node[:mediawiki][:user]
-    group node[:mediawiki][:group]
-    mode 0o644
+    owner node["mediawiki"]["user"]
+    group node["mediawiki"]["group"]
+    mode "644"
     backup false
   end
 
   cookbook_file "#{site_directory}/googled06a989d1ccc8364.html" do
     cookbook "mediawiki"
-    owner node[:mediawiki][:user]
-    group node[:mediawiki][:group]
-    mode 0o644
+    owner node["mediawiki"]["user"]
+    group node["mediawiki"]["group"]
+    mode "644"
     backup false
   end
 
   cookbook_file "#{site_directory}/googlefac54c35e800caab.html" do
     cookbook "mediawiki"
-    owner node[:mediawiki][:user]
-    group node[:mediawiki][:group]
-    mode 0o644
+    owner node["mediawiki"]["user"]
+    group node["mediawiki"]["group"]
+    mode "644"
     backup false
   end
 
@@ -504,8 +504,8 @@ action :create do
     action :nothing
     command "php extensions/CirrusSearch/maintenance/updateSearchIndexConfig.php"
     cwd mediawiki_directory
-    user node[:mediawiki][:user]
-    group node[:mediawiki][:group]
+    user node["mediawiki"]["user"]
+    group node["mediawiki"]["group"]
   end
 end
 
@@ -515,9 +515,9 @@ action :update do
   template "#{mediawiki_directory}/LocalSettings.php" do
     cookbook "mediawiki"
     source "LocalSettings.php.erb"
-    owner node[:mediawiki][:user]
-    group node[:mediawiki][:group]
-    mode 0o664
+    owner node["mediawiki"]["user"]
+    group node["mediawiki"]["group"]
+    mode "664"
     variables :name => new_resource.site,
               :directory => mediawiki_directory,
               :database_params => database_params,
@@ -529,8 +529,8 @@ action :update do
     action :run
     command "php maintenance/update.php --quick"
     cwd mediawiki_directory
-    user node[:mediawiki][:user]
-    group node[:mediawiki][:group]
+    user node["mediawiki"]["user"]
+    group node["mediawiki"]["group"]
   end
 end
 

--- a/cookbooks/mediawiki/resources/skin.rb
+++ b/cookbooks/mediawiki/resources/skin.rb
@@ -35,11 +35,11 @@ action :create do
     remote_directory skin_directory do
       cookbook "mediawiki"
       source new_resource.source
-      owner node[:mediawiki][:user]
-      group node[:mediawiki][:group]
-      mode 0o755
-      files_owner node[:mediawiki][:user]
-      files_group node[:mediawiki][:group]
+      owner node["mediawiki"]["user"]
+      group node["mediawiki"]["group"]
+      mode "755"
+      files_owner node["mediawiki"]["user"]
+      files_group node["mediawiki"]["group"]
       files_mode 0o755
     end
   else
@@ -51,8 +51,8 @@ action :create do
       repository skin_repository
       revision skin_revision
       enable_submodules true
-      user node[:mediawiki][:user]
-      group node[:mediawiki][:group]
+      user node["mediawiki"]["user"]
+      group node["mediawiki"]["group"]
       ignore_failure skin_repository.start_with?("git://github.com/wikimedia/mediawiki-skins")
     end
   end
@@ -61,9 +61,9 @@ action :create do
     declare_resource :template, "#{mediawiki_directory}/LocalSettings.d/Skin-#{new_resource.skin}.inc.php" do
       cookbook "mediawiki"
       source new_resource.template
-      user node[:mediawiki][:user]
-      group node[:mediawiki][:group]
-      mode 0o664
+      user node["mediawiki"]["user"]
+      group node["mediawiki"]["group"]
+      mode "664"
       variables new_resource.variables
     end
   else
@@ -77,9 +77,9 @@ action :create do
 
     file "#{mediawiki_directory}/LocalSettings.d/Skin-#{new_resource.skin}.inc.php" do
       content file_content
-      user node[:mediawiki][:user]
-      group node[:mediawiki][:group]
-      mode 0o664
+      user node["mediawiki"]["user"]
+      group node["mediawiki"]["group"]
+      mode "664"
       only_if { ::File.exist?(skin_file) }
     end
   end
@@ -98,7 +98,7 @@ end
 
 action_class do
   def site_directory
-    node[:mediawiki][:sites][new_resource.site][:directory]
+    node["mediawiki"]["sites"][new_resource.site]["directory"]
   end
 
   def mediawiki_directory
@@ -110,7 +110,7 @@ action_class do
   end
 
   def skin_version
-    new_resource.version || node[:mediawiki][:sites][new_resource.site][:version]
+    new_resource.version || node["mediawiki"]["sites"][new_resource.site]["version"]
   end
 
   def default_repository
@@ -122,7 +122,7 @@ def after_created
   if update_site
     notifies :update, "mediawiki_site[#{site}]"
   else
-    site_directory = node[:mediawiki][:sites][site][:directory]
+    site_directory = node["mediawiki"]["sites"][site]["directory"]
 
     notifies :create, "template[#{site_directory}/w/LocalSettings.php]"
     notifies :run, "execute[#{site_directory}/w/maintenance/update.php]"

--- a/cookbooks/memcached/metadata.rb
+++ b/cookbooks/memcached/metadata.rb
@@ -3,6 +3,5 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures memcached"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"

--- a/cookbooks/memcached/recipes/default.rb
+++ b/cookbooks/memcached/recipes/default.rb
@@ -28,7 +28,7 @@ template "/etc/memcached.conf" do
   source "memcached.conf.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
   notifies :restart, "service[memcached]"
 end
 

--- a/cookbooks/munin/metadata.rb
+++ b/cookbooks/munin/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures munin"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "apache"

--- a/cookbooks/munin/recipes/default.rb
+++ b/cookbooks/munin/recipes/default.rb
@@ -44,7 +44,7 @@ template "/etc/munin/munin-node.conf" do
   source "munin-node.conf.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
   variables :servers => servers
   notifies :restart, "service[munin-node]"
 end
@@ -53,7 +53,7 @@ remote_directory "/usr/local/share/munin/plugins" do
   source "plugins"
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
   files_owner "root"
   files_group "root"
   files_mode 0o755
@@ -64,7 +64,7 @@ remote_directory "/etc/munin/plugin-conf.d" do
   source "plugin-conf.d"
   owner "root"
   group "munin"
-  mode 0o750
+  mode "750"
   files_owner "root"
   files_group "root"
   files_mode 0o644
@@ -106,7 +106,7 @@ munin_plugin "diskstats"
 munin_plugin "entropy"
 munin_plugin "forks"
 
-if node[:kernel][:modules].include?("nf_conntrack")
+if node["kernel"]["modules"].include?("nf_conntrack")
   package "conntrack"
 
   munin_plugin "fw_conntrack"
@@ -159,11 +159,11 @@ munin_plugin "http_loadtime" do
   action :delete
 end
 
-node[:network][:interfaces].each do |ifname, ifattr|
+node["network"]["interfaces"].each do |ifname, ifattr|
   if ifattr[:flags]&.include?("UP") && !ifattr[:flags].include?("LOOPBACK")
-    if node[:hardware] &&
-       node[:hardware][:network] &&
-       node[:hardware][:network][ifname][:device] =~ /^virtio/
+    if node["hardware"] &&
+       node["hardware"]["network"] &&
+       node["hardware"]["network"][ifname]["device"] =~ /^virtio/
       munin_plugin_conf "if_#{ifname}" do
         template "if.erb"
         variables :ifname => ifname
@@ -235,7 +235,7 @@ munin_plugin "load"
 munin_plugin "memory"
 munin_plugin "netstat"
 
-if node[:kernel][:modules].include?("nfsv3")
+if node["kernel"]["modules"].include?("nfsv3")
   munin_plugin "nfs_client"
 else
   munin_plugin "nfs_client" do
@@ -243,7 +243,7 @@ else
   end
 end
 
-if node[:kernel][:modules].include?("nfsv4")
+if node["kernel"]["modules"].include?("nfsv4")
   munin_plugin "nfs4_client"
 else
   munin_plugin "nfs4_client" do
@@ -251,7 +251,7 @@ else
   end
 end
 
-if node[:kernel][:modules].include?("nfsd")
+if node["kernel"]["modules"].include?("nfsd")
   munin_plugin "nfsd"
   munin_plugin "nfsd4"
 else

--- a/cookbooks/munin/recipes/server.rb
+++ b/cookbooks/munin/recipes/server.rb
@@ -27,13 +27,13 @@ template "/etc/default/rrdcached" do
   source "rrdcached.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
 end
 
 directory "/var/lib/munin/rrdcached" do
   owner "munin"
   group "munin"
-  mode 0o755
+  mode "755"
 end
 
 service "rrdcached" do
@@ -62,7 +62,7 @@ template "/etc/munin/munin.conf" do
   source "munin.conf.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
   variables :expiry_time => expiry_time, :clients => clients,
             :frontends => frontends, :backends => backends,
             :tilecaches => tilecaches, :renderers => renderers,
@@ -77,7 +77,7 @@ remote_directory "/srv/munin.openstreetmap.org" do
   source "www"
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
   files_owner "root"
   files_group "root"
   files_mode 0o644
@@ -87,7 +87,7 @@ end
 directory "/srv/munin.openstreetmap.org/dumps" do
   owner "www-data"
   group "www-data"
-  mode 0o755
+  mode "755"
 end
 
 ssl_certificate "munin.openstreetmap.org" do
@@ -103,7 +103,7 @@ template "/etc/cron.daily/munin-backup" do
   source "backup.cron.erb"
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end
 
 munin_plugin "munin_stats"

--- a/cookbooks/munin/resources/plugin.rb
+++ b/cookbooks/munin/resources/plugin.rb
@@ -81,5 +81,5 @@ action_class do
 end
 
 def after_created
-  notifies :restart, "service[munin-node]" if restart_munin && node[:recipes].include?("munin")
+  notifies :restart, "service[munin-node]" if restart_munin && node["recipes"].include?("munin")
 end

--- a/cookbooks/munin/resources/plugin_conf.rb
+++ b/cookbooks/munin/resources/plugin_conf.rb
@@ -31,7 +31,7 @@ action :create do
     source new_resource.template
     owner "root"
     group "root"
-    mode 0o644
+    mode "644"
     variables new_resource.variables.merge(:name => new_resource.plugin_conf)
   end
 end

--- a/cookbooks/mysql/metadata.rb
+++ b/cookbooks/mysql/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures mysql"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "munin"

--- a/cookbooks/mysql/recipes/default.rb
+++ b/cookbooks/mysql/recipes/default.rb
@@ -29,7 +29,7 @@ template "/etc/mysql/mysql.conf.d/zzz-chef.cnf" do
   source "my.cnf.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
   notifies :restart, "service[mysql]"
 end
 

--- a/cookbooks/networking/definitions/firewall_rule.rb
+++ b/cookbooks/networking/definitions/firewall_rule.rb
@@ -31,12 +31,12 @@ define :firewall_rule, :action => :accept do
   ]
 
   if params[:family].nil?
-    node.default[:networking][:firewall][:inet] << rule
-    node.default[:networking][:firewall][:inet6] << rule
+    node.default["networking"]["firewall"]["inet"] << rule
+    node.default["networking"]["firewall"]["inet6"] << rule
   elsif params[:family].to_s == "inet"
-    node.default[:networking][:firewall][:inet] << rule
+    node.default["networking"]["firewall"]["inet"] << rule
   elsif params[:family].to_s == "inet6"
-    node.default[:networking][:firewall][:inet6] << rule
+    node.default["networking"]["firewall"]["inet6"] << rule
   else
     log "Unsupported network family" do
       level :error

--- a/cookbooks/networking/metadata.rb
+++ b/cookbooks/networking/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Configures networking"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 recipe            "networking", "Configures networking via attributes"
 supports          "ubuntu"

--- a/cookbooks/networking/recipes/default.rb
+++ b/cookbooks/networking/recipes/default.rb
@@ -33,24 +33,24 @@ netplan = {
   }
 }
 
-node[:networking][:interfaces].each do |name, interface|
+node["networking"]["interfaces"].each do |name, interface|
   if interface[:interface]
-    if interface[:role] && (role = node[:networking][:roles][interface[:role]])
+    if interface[:role] && (role = node["networking"]["roles"][interface[:role]])
       if role[interface[:family]]
-        node.normal[:networking][:interfaces][name][:prefix] = role[interface[:family]][:prefix]
-        node.normal[:networking][:interfaces][name][:gateway] = role[interface[:family]][:gateway]
+        node.normal["networking"]["interfaces"][name][:prefix] = role[interface[:family]][:prefix]
+        node.normal["networking"]["interfaces"][name][:gateway] = role[interface[:family]][:gateway]
       end
 
-      node.normal[:networking][:interfaces][name][:metric] = role[:metric]
-      node.normal[:networking][:interfaces][name][:zone] = role[:zone]
+      node.normal["networking"]["interfaces"][name][:metric] = role[:metric]
+      node.normal["networking"]["interfaces"][name][:zone] = role[:zone]
     end
 
-    prefix = node[:networking][:interfaces][name][:prefix]
+    prefix = node["networking"]["interfaces"][name]["prefix"]
 
-    node.normal[:networking][:interfaces][name][:netmask] = (~IPAddr.new(interface[:address]).mask(0)).mask(prefix)
-    node.normal[:networking][:interfaces][name][:network] = IPAddr.new(interface[:address]).mask(prefix)
+    node.normal["networking"]["interfaces"][name][:netmask] = (~IPAddr.new(interface[:address]).mask(0)).mask(prefix)
+    node.normal["networking"]["interfaces"][name][:network] = IPAddr.new(interface[:address]).mask(prefix)
 
-    interface = node[:networking][:interfaces][name]
+    interface = node["networking"]["interfaces"][name]
 
     deviceplan = if interface[:interface] =~ /^(.*)\.(\d+)$/
                    netplan["network"]["vlans"][interface[:interface]] ||= {
@@ -152,7 +152,7 @@ end
 file "/etc/netplan/99-chef.yaml" do
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
   content YAML.dump(netplan)
 end
 
@@ -169,7 +169,7 @@ template "/etc/hostname" do
   source "hostname.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
   notifies :run, "execute[hostname]"
 end
 
@@ -177,7 +177,7 @@ template "/etc/hosts" do
   source "hosts.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
 end
 
 service "systemd-resolved" do
@@ -187,24 +187,24 @@ end
 directory "/etc/systemd/resolved.conf.d" do
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end
 
 template "/etc/systemd/resolved.conf.d/99-chef.conf" do
   source "resolved.conf.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
   notifies :restart, "service[systemd-resolved]"
 end
 
-if node[:networking][:tcp_fastopen_key]
+if node["networking"]["tcp_fastopen_key"]
   fastopen_keys = data_bag_item("networking", "fastopen")
 
-  node.normal[:sysctl][:tcp_fastopen] = {
+  node.normal["sysctl"][:tcp_fastopen] = {
     :comment => "Set shared key for TCP fast open",
     :parameters => {
-      "net.ipv4.tcp_fastopen_key" => fastopen_keys[node[:networking][:tcp_fastopen_key]]
+      "net.ipv4.tcp_fastopen_key" => fastopen_keys[node["networking"]["tcp_fastopen_key"]]
     }
   }
 end
@@ -240,7 +240,7 @@ end
 zones = {}
 
 search(:node, "networking:interfaces").collect do |n|
-  next if n[:fqdn] == node[:fqdn]
+  next if n[:fqdn] == node["fqdn"]
 
   n.interfaces.each do |interface|
     next unless interface[:role] == "external" && interface[:zone]
@@ -257,7 +257,7 @@ template "/etc/default/shorewall" do
   source "shorewall-default.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
   notifies :restart, "service[shorewall]"
 end
 
@@ -265,7 +265,7 @@ template "/etc/shorewall/shorewall.conf" do
   source "shorewall.conf.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
   notifies :restart, "service[shorewall]"
 end
 
@@ -273,7 +273,7 @@ template "/etc/shorewall/zones" do
   source "shorewall-zones.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
   variables :type => "ipv4"
   notifies :restart, "service[shorewall]"
 end
@@ -282,7 +282,7 @@ template "/etc/shorewall/interfaces" do
   source "shorewall-interfaces.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
   notifies :restart, "service[shorewall]"
 end
 
@@ -290,7 +290,7 @@ template "/etc/shorewall/hosts" do
   source "shorewall-hosts.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
   variables :zones => zones
   notifies :restart, "service[shorewall]"
 end
@@ -299,16 +299,16 @@ template "/etc/shorewall/conntrack" do
   source "shorewall-conntrack.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
   notifies :restart, "service[shorewall]"
-  only_if { node[:networking][:firewall][:raw] }
+  only_if { node["networking"]["firewall"]["raw"] }
 end
 
 template "/etc/shorewall/policy" do
   source "shorewall-policy.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
   notifies :restart, "service[shorewall]"
 end
 
@@ -316,7 +316,7 @@ template "/etc/shorewall/rules" do
   source "shorewall-rules.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
   variables :family => "inet"
   notifies :restart, "service[shorewall]"
 end
@@ -331,7 +331,7 @@ template "/etc/logrotate.d/shorewall" do
   source "logrotate.shorewall.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
   variables :name => "shorewall"
 end
 
@@ -356,12 +356,12 @@ end
   end
 end
 
-if node[:roles].include?("gateway")
+if node["roles"].include?("gateway")
   template "/etc/shorewall/masq" do
     source "shorewall-masq.erb"
     owner "root"
     group "root"
-    mode 0o644
+    mode "644"
     notifies :restart, "service[shorewall]"
   end
 else
@@ -378,7 +378,7 @@ unless node.interfaces(:family => :inet6).empty?
     source "shorewall-default.erb"
     owner "root"
     group "root"
-    mode 0o644
+    mode "644"
     notifies :restart, "service[shorewall6]"
   end
 
@@ -386,7 +386,7 @@ unless node.interfaces(:family => :inet6).empty?
     source "shorewall6.conf.erb"
     owner "root"
     group "root"
-    mode 0o644
+    mode "644"
     notifies :restart, "service[shorewall6]"
   end
 
@@ -394,7 +394,7 @@ unless node.interfaces(:family => :inet6).empty?
     source "shorewall-zones.erb"
     owner "root"
     group "root"
-    mode 0o644
+    mode "644"
     variables :type => "ipv6"
     notifies :restart, "service[shorewall6]"
   end
@@ -403,7 +403,7 @@ unless node.interfaces(:family => :inet6).empty?
     source "shorewall6-interfaces.erb"
     owner "root"
     group "root"
-    mode 0o644
+    mode "644"
     notifies :restart, "service[shorewall6]"
   end
 
@@ -411,7 +411,7 @@ unless node.interfaces(:family => :inet6).empty?
     source "shorewall6-hosts.erb"
     owner "root"
     group "root"
-    mode 0o644
+    mode "644"
     variables :zones => zones
     notifies :restart, "service[shorewall6]"
   end
@@ -420,16 +420,16 @@ unless node.interfaces(:family => :inet6).empty?
     source "shorewall-conntrack.erb"
     owner "root"
     group "root"
-    mode 0o644
+    mode "644"
     notifies :restart, "service[shorewall6]"
-    only_if { node[:networking][:firewall][:raw] }
+    only_if { node["networking"]["firewall"]["raw"] }
   end
 
   template "/etc/shorewall6/policy" do
     source "shorewall-policy.erb"
     owner "root"
     group "root"
-    mode 0o644
+    mode "644"
     notifies :restart, "service[shorewall6]"
   end
 
@@ -437,7 +437,7 @@ unless node.interfaces(:family => :inet6).empty?
     source "shorewall-rules.erb"
     owner "root"
     group "root"
-    mode 0o644
+    mode "644"
     variables :family => "inet6"
     notifies :restart, "service[shorewall6]"
   end
@@ -452,7 +452,7 @@ unless node.interfaces(:family => :inet6).empty?
     source "logrotate.shorewall.erb"
     owner "root"
     group "root"
-    mode 0o644
+    mode "644"
     variables :name => "shorewall6"
   end
 
@@ -473,8 +473,8 @@ firewall_rule "accept-http" do
   dest "fw"
   proto "tcp:syn"
   dest_ports "http"
-  rate_limit node[:networking][:firewall][:http_rate_limit]
-  connection_limit node[:networking][:firewall][:http_connection_limit]
+  rate_limit node["networking"]["firewall"]["http_rate_limit"]
+  connection_limit node["networking"]["firewall"]["http_connection_limit"]
 end
 
 firewall_rule "accept-https" do
@@ -483,6 +483,6 @@ firewall_rule "accept-https" do
   dest "fw"
   proto "tcp:syn"
   dest_ports "https"
-  rate_limit node[:networking][:firewall][:http_rate_limit]
-  connection_limit node[:networking][:firewall][:http_connection_limit]
+  rate_limit node["networking"]["firewall"]["http_rate_limit"]
+  connection_limit node["networking"]["firewall"]["http_connection_limit"]
 end

--- a/cookbooks/nfs/metadata.rb
+++ b/cookbooks/nfs/metadata.rb
@@ -3,6 +3,5 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures nfs"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"

--- a/cookbooks/nfs/recipes/default.rb
+++ b/cookbooks/nfs/recipes/default.rb
@@ -19,7 +19,7 @@
 
 package "nfs-common"
 
-node[:nfs].each do |mountpoint, details|
+node["nfs"].each do |mountpoint, details|
   mount_options = if details[:readonly]
                     "ro,bg,soft,tcp,rsize=8192,wsize=8192,nfsvers=4"
                   else
@@ -29,7 +29,7 @@ node[:nfs].each do |mountpoint, details|
   directory mountpoint do
     owner "root"
     group "root"
-    mode 0o755
+    mode "755"
     recursive true
     not_if { File.exist?(mountpoint) }
   end

--- a/cookbooks/nfs/recipes/server.rb
+++ b/cookbooks/nfs/recipes/server.rb
@@ -33,7 +33,7 @@ search(:node, "*:*") do |client|
   next unless client[:nfs]
 
   client[:nfs].each_value do |mount|
-    next unless mount[:host] == node[:hostname]
+    next unless mount[:host] == node["hostname"]
 
     client.ipaddresses do |address|
       exports[mount[:path]] ||= {}
@@ -56,7 +56,7 @@ template "/etc/exports" do
   source "exports.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
   variables :exports => exports
   notifies :run, "execute[exportfs]"
 end

--- a/cookbooks/nginx/metadata.rb
+++ b/cookbooks/nginx/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures nginx"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "ssl"

--- a/cookbooks/nginx/recipes/default.rb
+++ b/cookbooks/nginx/recipes/default.rb
@@ -19,7 +19,7 @@
 
 package "nginx"
 
-resolvers = node[:networking][:nameservers].map do |resolver|
+resolvers = node["networking"]["nameservers"].map do |resolver|
   IPAddr.new(resolver).ipv6? ? "[#{resolver}]" : resolver
 end
 
@@ -27,22 +27,22 @@ template "/etc/nginx/nginx.conf" do
   source "nginx.conf.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
   variables :resolvers => resolvers
 end
 
 directory "/var/cache/nginx/fastcgi-cache" do
   owner "www-data"
   group "root"
-  mode 0o755
-  only_if { node[:nginx][:cache][:fastcgi][:enable] }
+  mode "755"
+  only_if { node["nginx"]["cache"]["fastcgi"]["enable"] }
 end
 
 directory "/var/cache/nginx/proxy-cache" do
   owner "www-data"
   group "root"
-  mode 0o755
-  only_if { node[:nginx][:cache][:proxy][:enable] }
+  mode "755"
+  only_if { node["nginx"]["cache"]["proxy"]["enable"] }
 end
 
 service "nginx" do

--- a/cookbooks/nginx/resources/site.rb
+++ b/cookbooks/nginx/resources/site.rb
@@ -32,7 +32,7 @@ action :create do
     source new_resource.template
     owner "root"
     group "root"
-    mode 0o644
+    mode "644"
     variables new_resource.variables.merge(:name => new_resource.site, :directory => directory)
   end
 end

--- a/cookbooks/nodejs/metadata.rb
+++ b/cookbooks/nodejs/metadata.rb
@@ -3,6 +3,5 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures Node.js"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"

--- a/cookbooks/nodejs/resources/package.rb
+++ b/cookbooks/nodejs/resources/package.rb
@@ -17,7 +17,6 @@
 # limitations under the License.
 #
 
-require "chef/mixin/shell_out"
 require "json"
 
 default_action :install
@@ -61,8 +60,6 @@ action :remove do
 end
 
 action_class do
-  include Chef::Mixin::ShellOut
-
   def current_version
     @current_version ||= JSON.parse(shell_out("npm list --global --json").stdout)
                              .dig("dependencies", new_resource.package, "version")

--- a/cookbooks/nominatim/metadata.rb
+++ b/cookbooks/nominatim/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures nominatim servers"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "apache"

--- a/cookbooks/ntp/metadata.rb
+++ b/cookbooks/ntp/metadata.rb
@@ -3,6 +3,5 @@ maintainer        "Opscode, Inc."
 maintainer_email  "cookbooks@opscode.com"
 license           "Apache-2.0"
 description       "Installs and configures ntp as a client or server"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "0.8.2"
 supports          "ubuntu"

--- a/cookbooks/ntp/recipes/default.rb
+++ b/cookbooks/ntp/recipes/default.rb
@@ -30,7 +30,7 @@ execute "dpkg-reconfigure-tzdata" do
 end
 
 link "/etc/localtime" do
-  to "/usr/share/zoneinfo/#{node[:ntp][:tz]}"
+  to "/usr/share/zoneinfo/#{node['ntp']['tz']}"
   owner "root"
   group "root"
   notifies :run, "execute[dpkg-reconfigure-tzdata]", :immediately
@@ -40,7 +40,7 @@ template "/etc/chrony/chrony.conf" do
   source "chrony.conf.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
   notifies :restart, "service[chrony]"
 end
 

--- a/cookbooks/ohai/metadata.rb
+++ b/cookbooks/ohai/metadata.rb
@@ -3,6 +3,5 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Configures ohai"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"

--- a/cookbooks/ohai/resources/plugin.rb
+++ b/cookbooks/ohai/resources/plugin.rb
@@ -31,7 +31,7 @@ action :create do
     source new_resource.template
     owner "root"
     group "root"
-    mode 0o644
+    mode "644"
     notifies :reload, "ohai[#{new_resource.plugin}]"
   end
 end

--- a/cookbooks/openssh/recipes/default.rb
+++ b/cookbooks/openssh/recipes/default.rb
@@ -64,14 +64,14 @@ end
 
 template "/etc/ssh/ssh_config" do
   source "ssh_config.erb"
-  mode 0o644
+  mode "644"
   owner "root"
   group "root"
 end
 
 template "/etc/ssh/ssh_known_hosts" do
   source "ssh_known_hosts.erb"
-  mode 0o444
+  mode "444"
   owner "root"
   group "root"
   backup false
@@ -85,5 +85,5 @@ firewall_rule "accept-ssh" do
   source "net"
   dest "fw"
   proto "tcp:syn"
-  dest_ports node[:openssh][:port]
+  dest_ports node["openssh"]["port"]
 end

--- a/cookbooks/openvpn/metadata.rb
+++ b/cookbooks/openvpn/metadata.rb
@@ -3,6 +3,5 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures OpenVPN"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"

--- a/cookbooks/osmosis/metadata.rb
+++ b/cookbooks/osmosis/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures osmosis"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "chef"

--- a/cookbooks/osmosis/recipes/default.rb
+++ b/cookbooks/osmosis/recipes/default.rb
@@ -22,8 +22,8 @@ include_recipe "chef"
 package "unzip"
 package "default-jre"
 
-osmosis_package = "osmosis-#{node[:osmosis][:version]}.zip"
-osmosis_directory = "/opt/osmosis-#{node[:osmosis][:version]}"
+osmosis_package = "osmosis-#{node['osmosis']['version']}.zip"
+osmosis_directory = "/opt/osmosis-#{node['osmosis']['version']}"
 
 Dir.glob("/var/cache/chef/osmosis-*.zip").each do |zip|
   next if zip == "/var/cache/chef/#{osmosis_package}"
@@ -37,7 +37,7 @@ end
 directory osmosis_directory do
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end
 
 execute "/var/cache/chef/#{osmosis_package}" do
@@ -53,7 +53,7 @@ remote_file "/var/cache/chef/#{osmosis_package}" do
   source "https://bretth.dev.openstreetmap.org/osmosis-build/#{osmosis_package}"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
   backup false
   notifies :run, "execute[/var/cache/chef/#{osmosis_package}]"
 end

--- a/cookbooks/osqa/metadata.rb
+++ b/cookbooks/osqa/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures OSQA"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "apache"

--- a/cookbooks/osqa/recipes/default.rb
+++ b/cookbooks/osqa/recipes/default.rb
@@ -73,17 +73,17 @@ end
 apache_module "rewrite"
 apache_module "wsgi"
 
-node[:osqa][:sites].each do |site|
+node["osqa"]["sites"].each do |site|
   site_name = site[:name]
   site_aliases = site[:aliases] || []
   directory = site[:directory] || "/srv/#{site_name}"
-  site_user = site[:user] || node[:osqa][:user]
+  site_user = site[:user] || node["osqa"]["user"]
   site_user = Etc.getpwuid(site_user).name if site_user.is_a?(Integer)
-  site_group = site[:group] || node[:osqa][:group] || Etc.getpwnam(site_user).gid
+  site_group = site[:group] || node["osqa"]["group"] || Etc.getpwnam(site_user).gid
   site_group = Etc.getgrgid(site_group).name if site_group.is_a?(Integer)
-  database_name = site[:database_name] || node[:osqa][:database_name]
-  database_user = site[:database_user] || node[:osqa][:database_user]
-  database_password = site[:database_user] || node[:osqa][:database_password]
+  database_name = site[:database_name] || node["osqa"]["database_name"]
+  database_user = site[:database_user] || node["osqa"]["database_user"]
+  database_password = site[:database_user] || node["osqa"]["database_password"]
   backup_name = site[:backup]
 
   ssl_certificate site_name do
@@ -100,7 +100,7 @@ node[:osqa][:sites].each do |site|
   directory directory do
     owner site_user
     group site_group
-    mode 0o755
+    mode "755"
   end
 
   execute "osqa-migrate" do
@@ -124,14 +124,14 @@ node[:osqa][:sites].each do |site|
   directory "#{directory}/upfiles" do
     user site_user
     group site_group
-    mode 0o755
+    mode "755"
   end
 
   template "#{directory}/osqa/osqa.wsgi" do
     source "osqa.wsgi.erb"
     owner site_user
     group site_group
-    mode 0o644
+    mode "644"
     variables :directory => directory
     notifies :reload, "service[apache2]"
   end
@@ -153,7 +153,7 @@ node[:osqa][:sites].each do |site|
   file "#{directory}/osqa/settings_local.py" do
     owner site_user
     group site_group
-    mode 0o644
+    mode "644"
     content settings
     notifies :reload, "service[apache2]"
   end
@@ -162,7 +162,7 @@ node[:osqa][:sites].each do |site|
     source "backup.cron.erb"
     owner "root"
     group "root"
-    mode 0o755
+    mode "755"
     variables :name => backup_name, :directory => directory, :user => site_user, :database => database_name
   end
 end

--- a/cookbooks/otrs/metadata.rb
+++ b/cookbooks/otrs/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures OTRS"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "apache"

--- a/cookbooks/otrs/recipes/default.rb
+++ b/cookbooks/otrs/recipes/default.rb
@@ -40,14 +40,14 @@ package "libtemplate-perl"
 
 apache_module "headers"
 
-version = node[:otrs][:version]
-user = node[:otrs][:user]
-database_cluster = node[:otrs][:database_cluster]
-database_name = node[:otrs][:database_name]
-database_user = node[:otrs][:database_user]
-database_password = passwords[node[:otrs][:database_password]]
-site = node[:otrs][:site]
-site_aliases = node[:otrs][:site_aliases] || []
+version = node["otrs"]["version"]
+user = node["otrs"]["user"]
+database_cluster = node["otrs"]["database_cluster"]
+database_name = node["otrs"]["database_name"]
+database_user = node["otrs"]["database_user"]
+database_password = passwords[node["otrs"]["database_password"]]
+site = node["otrs"]["site"]
+site_aliases = node["otrs"]["site_aliases"] || []
 
 postgresql_user database_user do
   cluster database_cluster
@@ -88,7 +88,7 @@ end
 file "/opt/otrs-#{version}/Kernel/Config.pm" do
   owner user
   group "www-data"
-  mode 0o664
+  mode "664"
   content config
 end
 
@@ -125,7 +125,7 @@ Dir.glob("/opt/otrs/var/cron/*.dist") do |distname|
   file name do
     owner "otrs"
     group "www-data"
-    mode 0o664
+    mode "664"
     content IO.read(distname)
     notifies :run, "execute[/opt/otrs/bin/Cron.sh]"
   end
@@ -145,12 +145,12 @@ template "/etc/sudoers.d/otrs" do
   source "sudoers.erb"
   owner "root"
   group "root"
-  mode 0o440
+  mode "440"
 end
 
 template "/etc/cron.daily/otrs-backup" do
   source "backup.cron.erb"
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end

--- a/cookbooks/passenger/attributes/default.rb
+++ b/cookbooks/passenger/attributes/default.rb
@@ -3,4 +3,4 @@ default[:passenger][:max_pool_size] = 6
 default[:passenger][:pool_idle_time] = 300
 default[:passenger][:instance_registry_dir] = "/run/passenger"
 
-default[:apt][:sources] = node[:apt][:sources] | ["passenger"]
+default[:apt][:sources] = node["apt"]["sources"] | ["passenger"]

--- a/cookbooks/passenger/metadata.rb
+++ b/cookbooks/passenger/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures passenger"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "apache"

--- a/cookbooks/passenger/recipes/default.rb
+++ b/cookbooks/passenger/recipes/default.rb
@@ -19,23 +19,23 @@
 
 include_recipe "apache"
 
-package "ruby#{node[:passenger][:ruby_version]}"
-package "ruby#{node[:passenger][:ruby_version]}-dev"
+package "ruby#{node['passenger']['ruby_version']}"
+package "ruby#{node['passenger']['ruby_version']}-dev"
 
-if node[:passenger][:ruby_version].to_f < 1.9
-  package "rubygems#{node[:passenger][:ruby_version]}"
-  package "irb#{node[:passenger][:ruby_version]}"
+if node["passenger"]["ruby_version"].to_f < 1.9
+  package "rubygems#{node['passenger']['ruby_version']}"
+  package "irb#{node['passenger']['ruby_version']}"
 end
 
 template "/usr/local/bin/passenger-ruby" do
   source "ruby.erb"
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
   notifies :reload, "service[apache2]"
 end
 
-systemd_tmpfile node[:passenger][:instance_registry_dir] do
+systemd_tmpfile node["passenger"]["instance_registry_dir"] do
   type "d"
   owner "root"
   group "root"

--- a/cookbooks/passenger/resources/application.rb
+++ b/cookbooks/passenger/resources/application.rb
@@ -25,7 +25,7 @@ action :restart do
   execute new_resource.application do
     action :run
     command "passenger-config restart-app --ignore-app-not-running --ignore-passenger-not-running #{new_resource.application}"
-    environment "PASSENGER_INSTANCE_REGISTRY_DIR" => node[:passenger][:instance_registry_dir]
+    environment "PASSENGER_INSTANCE_REGISTRY_DIR" => node["passenger"]["instance_registry_dir"]
     user "root"
     group "root"
   end

--- a/cookbooks/piwik/metadata.rb
+++ b/cookbooks/piwik/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures Piwik"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "apache"

--- a/cookbooks/piwik/recipes/default.rb
+++ b/cookbooks/piwik/recipes/default.rb
@@ -37,7 +37,7 @@ apache_module "expires"
 apache_module "php7.2"
 apache_module "rewrite"
 
-version = node[:piwik][:version]
+version = node["piwik"]["version"]
 
 directory "/opt/piwik-#{version}" do
   owner "root"
@@ -79,7 +79,7 @@ template "/opt/piwik-#{version}/piwik/config/config.ini.php" do
   mode "0644"
   variables :passwords => passwords,
             :directory => "/opt/piwik-#{version}/piwik",
-            :plugins => node[:piwik][:plugins]
+            :plugins => node["piwik"]["plugins"]
 end
 
 directory "/opt/piwik-#{version}/piwik/tmp" do

--- a/cookbooks/planet/metadata.rb
+++ b/cookbooks/planet/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures a planet server"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "apache"

--- a/cookbooks/planet/recipes/current.rb
+++ b/cookbooks/planet/recipes/current.rb
@@ -25,20 +25,20 @@ template "/usr/local/bin/planet-update" do
   source "planet-update.erb"
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end
 
 template "/usr/local/bin/planet-update-file" do
   source "planet-update-file.erb"
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end
 
 directory "/var/lib/planet" do
   owner "planet"
   group "planet"
-  mode 0o755
+  mode "755"
 end
 
 remote_file "/var/lib/planet/planet.pbf" do
@@ -46,19 +46,19 @@ remote_file "/var/lib/planet/planet.pbf" do
   source "https://planet.openstreetmap.org/pbf/planet-latest.osm.pbf"
   owner "planet"
   group "planet"
-  mode 0o644
+  mode "644"
 end
 
 template "/etc/cron.d/planet-update" do
   source "planet-update.cron.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
 end
 
 template "/etc/logrotate.d/planet-update" do
   source "planet-update.logrotate.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
 end

--- a/cookbooks/planet/recipes/default.rb
+++ b/cookbooks/planet/recipes/default.rb
@@ -45,17 +45,17 @@ remote_directory "/store/planet#cgi" do
   source "cgi"
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
   files_owner "root"
   files_group "root"
   files_mode 0o755
 end
 
-remote_directory node[:planet][:dump][:xml_history_directory] do
+remote_directory node["planet"]["dump"]["xml_history_directory"] do
   source "history_cgi"
   owner "www-data"
   group "planet"
-  mode 0o775
+  mode "775"
   files_owner "root"
   files_group "root"
   files_mode 0o755
@@ -65,7 +65,7 @@ remote_directory "/store/planet/cc-by-sa/full-experimental" do
   source "ccbysa_history_cgi"
   owner "www-data"
   group "planet"
-  mode 0o775
+  mode "775"
   files_owner "root"
   files_group "root"
   files_mode 0o755
@@ -73,24 +73,24 @@ end
 
 [:xml_directory, :xml_history_directory,
  :pbf_directory, :pbf_history_directory].each do |dir|
-  directory node[:planet][:dump][dir] do
+  directory node["planet"]["dump"][dir] do
     owner "www-data"
     group "planet"
-    mode 0o775
+    mode "775"
   end
 end
 
 directory "/store/planet/notes" do
   owner "www-data"
   group "planet"
-  mode 0o775
+  mode "775"
 end
 
 template "/usr/local/bin/apache-latest-planet-filename" do
   source "apache-latest-planet-filename.erb"
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
   notifies :restart, "service[apache2]"
 end
 
@@ -111,7 +111,7 @@ template "/etc/logrotate.d/apache2" do
   source "logrotate.apache.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
 end
 
 munin_plugin "planet_age"
@@ -120,12 +120,12 @@ template "/usr/local/bin/old-planet-file-cleanup" do
   source "old-planet-file-cleanup.erb"
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end
 
 template "/etc/cron.d/old-planet-file-cleanup" do
   source "old-planet-file-cleanup.cron.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
 end

--- a/cookbooks/planet/recipes/dump.rb
+++ b/cookbooks/planet/recipes/dump.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-node.default[:incron][:planetdump] = {
+node.default["incron"][:planetdump] = {
   :user => "www-data",
   :path => "/store/backup",
   :events => %w[IN_CREATE IN_MOVED_TO],
@@ -49,7 +49,7 @@ package "php-curl"
 directory "/opt/planet-dump-ng" do
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end
 
 git "/opt/planet-dump-ng" do
@@ -90,7 +90,7 @@ end
 directory "/store/planetdump" do
   owner "www-data"
   group "www-data"
-  mode 0o755
+  mode "755"
 end
 
 %w[planetdump planet-mirror-redirect-update].each do |program|
@@ -98,7 +98,7 @@ end
     source "#{program}.erb"
     owner "root"
     group "root"
-    mode 0o755
+    mode "755"
   end
 end
 
@@ -106,5 +106,5 @@ template "/etc/cron.d/planet-dump-mirror" do
   source "planet-dump-mirror-cron.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
 end

--- a/cookbooks/planet/recipes/notes.rb
+++ b/cookbooks/planet/recipes/notes.rb
@@ -27,7 +27,7 @@ package "python-lxml"
 directory "/opt/planet-notes-dump" do
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end
 
 git "/opt/planet-notes-dump" do
@@ -41,7 +41,7 @@ template "/usr/local/bin/planet-notes-dump" do
   source "planet-notes-dump.erb"
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
   variables :password => db_passwords["planetdump"]
 end
 
@@ -49,5 +49,5 @@ template "/etc/cron.d/planet-notes-dump" do
   source "planet-notes-dump.cron.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
 end

--- a/cookbooks/planet/recipes/replication.rb
+++ b/cookbooks/planet/recipes/replication.rb
@@ -37,7 +37,7 @@ remote_directory "/opt/flush" do
   source "flush"
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
   files_owner "root"
   files_group "root"
   files_mode 0o755
@@ -56,7 +56,7 @@ remote_directory "/usr/local/bin" do
   source "replication-bin"
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
   files_owner "root"
   files_group "root"
   files_mode 0o755
@@ -66,21 +66,21 @@ template "/usr/local/bin/users-agreed" do
   source "users-agreed.erb"
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end
 
 template "/usr/local/bin/users-deleted" do
   source "users-deleted.erb"
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end
 
 remote_directory "/store/planet/users_deleted" do
   source "users_deleted"
   owner "planet"
   group "planet"
-  mode 0o755
+  mode "755"
   files_owner "root"
   files_group "root"
   files_mode 0o644
@@ -90,7 +90,7 @@ remote_directory "/store/planet/replication" do
   source "replication-cgi"
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
   files_owner "root"
   files_group "root"
   files_mode 0o755
@@ -99,38 +99,38 @@ end
 directory "/store/planet/replication/changesets" do
   owner "planet"
   group "planet"
-  mode 0o755
+  mode "755"
 end
 
 directory "/store/planet/replication/day" do
   owner "planet"
   group "planet"
-  mode 0o755
+  mode "755"
 end
 
 directory "/store/planet/replication/hour" do
   owner "planet"
   group "planet"
-  mode 0o755
+  mode "755"
 end
 
 directory "/store/planet/replication/minute" do
   owner "planet"
   group "planet"
-  mode 0o755
+  mode "755"
 end
 
 directory "/etc/replication" do
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end
 
 template "/etc/replication/auth.conf" do
   source "replication.auth.erb"
   user "root"
   group "planet"
-  mode 0o640
+  mode "640"
   variables :password => db_passwords["planetdiff"]
 end
 
@@ -138,7 +138,7 @@ template "/etc/replication/changesets.conf" do
   source "changesets.conf.erb"
   user "root"
   group "planet"
-  mode 0o640
+  mode "640"
   variables :password => db_passwords["planetdiff"]
 end
 
@@ -146,27 +146,27 @@ template "/etc/replication/users-agreed.conf" do
   source "users-agreed.conf.erb"
   user "planet"
   group "planet"
-  mode 0o600
+  mode "600"
   variables :password => db_passwords["planetdiff"]
 end
 
 directory "/var/lib/replication" do
   owner "planet"
   group "planet"
-  mode 0o755
+  mode "755"
 end
 
 directory "/var/lib/replication/hour" do
   owner "planet"
   group "planet"
-  mode 0o755
+  mode "755"
 end
 
 template "/var/lib/replication/hour/configuration.txt" do
   source "replication.config.erb"
   owner "planet"
   group "planet"
-  mode 0o644
+  mode "644"
   variables :base => "minute", :interval => 3600
 end
 
@@ -177,14 +177,14 @@ end
 directory "/var/lib/replication/day" do
   owner "planet"
   group "planet"
-  mode 0o755
+  mode "755"
 end
 
 template "/var/lib/replication/day/configuration.txt" do
   source "replication.config.erb"
   owner "planet"
   group "planet"
-  mode 0o644
+  mode "644"
   variables :base => "hour", :interval => 86400
 end
 
@@ -192,12 +192,12 @@ link "/var/lib/replication/day/data" do
   to "/store/planet/replication/day"
 end
 
-if node[:planet][:replication] == "enabled"
+if node["planet"]["replication"] == "enabled"
   template "/etc/cron.d/replication" do
     source "replication.cron.erb"
     owner "root"
     group "root"
-    mode 0o644
+    mode "644"
   end
 else
   file "/etc/cron.d/replication" do

--- a/cookbooks/postgresql/metadata.rb
+++ b/cookbooks/postgresql/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures postgresql"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "ohai"

--- a/cookbooks/postgresql/recipes/default.rb
+++ b/cookbooks/postgresql/recipes/default.rb
@@ -19,20 +19,20 @@
 
 package "postgresql-common"
 
-node[:postgresql][:versions].each do |version|
+node["postgresql"]["versions"].each do |version|
   package "postgresql-#{version}"
   package "postgresql-client-#{version}"
   package "postgresql-contrib-#{version}"
   package "postgresql-server-dev-#{version}"
 
-  defaults = node[:postgresql][:settings][:defaults] || {}
-  settings = node[:postgresql][:settings][version] || {}
+  defaults = node["postgresql"]["settings"]["defaults"] || {}
+  settings = node["postgresql"]["settings"][version] || {}
 
   template "/etc/postgresql/#{version}/main/postgresql.conf" do
     source "postgresql.conf.erb"
     owner "postgres"
     group "postgres"
-    mode 0o644
+    mode "644"
     variables :version => version, :defaults => defaults, :settings => settings
     notifies :reload, "service[postgresql]"
   end
@@ -41,7 +41,7 @@ node[:postgresql][:versions].each do |version|
     source "pg_hba.conf.erb"
     owner "postgres"
     group "postgres"
-    mode 0o640
+    mode "640"
     variables :early_rules => settings[:early_authentication_rules] || defaults[:early_authentication_rules],
               :late_rules => settings[:late_authentication_rules] || defaults[:late_authentication_rules]
     notifies :reload, "service[postgresql]"
@@ -51,7 +51,7 @@ node[:postgresql][:versions].each do |version|
     source "pg_ident.conf.erb"
     owner "postgres"
     group "postgres"
-    mode 0o640
+    mode "640"
     variables :maps => settings[:user_name_maps] || defaults[:user_name_maps]
     notifies :reload, "service[postgresql]"
   end
@@ -78,7 +78,7 @@ node[:postgresql][:versions].each do |version|
       source "recovery.conf.erb"
       owner "postgres"
       group "postgres"
-      mode 0o640
+      mode "640"
       variables :standby_mode => standby_mode,
                 :primary_conninfo => primary_conninfo,
                 :restore_command => restore_command,
@@ -105,7 +105,7 @@ end
 package "ptop"
 package "libdbd-pg-perl"
 
-clusters = node[:postgresql][:clusters] || []
+clusters = node["postgresql"]["clusters"] || []
 
 clusters.each do |name, details|
   suffix = name.tr("/", ":")

--- a/cookbooks/postgresql/resources/munin.rb
+++ b/cookbooks/postgresql/resources/munin.rb
@@ -24,7 +24,7 @@ property :cluster, :kind_of => String, :required => true
 property :database, :kind_of => String, :required => true
 
 action :create do
-  cluster = node[:postgresql][:clusters] && node[:postgresql][:clusters][new_resource.cluster]
+  cluster = node["postgresql"]["clusters"] && node["postgresql"]["clusters"][new_resource.cluster]
   database = new_resource.database
 
   if cluster

--- a/cookbooks/python/metadata.rb
+++ b/cookbooks/python/metadata.rb
@@ -3,6 +3,5 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures Python"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"

--- a/cookbooks/roundup/metadata.rb
+++ b/cookbooks/roundup/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures a roundup server"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "apache"

--- a/cookbooks/rsyncd/metadata.rb
+++ b/cookbooks/rsyncd/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Configures rsyncd"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "networking"

--- a/cookbooks/rsyncd/recipes/default.rb
+++ b/cookbooks/rsyncd/recipes/default.rb
@@ -22,7 +22,7 @@ include_recipe "networking"
 hosts_allow = {}
 hosts_deny = {}
 
-node[:rsyncd][:modules].each do |name, details|
+node["rsyncd"]["modules"].each do |name, details|
   hosts_allow[name] = details[:hosts_allow] || []
 
   if details[:nodes_allow]
@@ -51,7 +51,7 @@ template "/etc/default/rsync" do
   source "rsync.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
   notifies :restart, "service[rsync]"
 end
 
@@ -59,7 +59,7 @@ template "/etc/rsyncd.conf" do
   source "rsyncd.conf.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
   variables :hosts_allow => hosts_allow, :hosts_deny => hosts_deny
 end
 

--- a/cookbooks/serverinfo/metadata.rb
+++ b/cookbooks/serverinfo/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Configures server-info web site"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "apache"

--- a/cookbooks/serverinfo/recipes/default.rb
+++ b/cookbooks/serverinfo/recipes/default.rb
@@ -38,7 +38,7 @@ roles = { :rows => search(:role, "*:*") }
 
 file "/srv/hardware.openstreetmap.org/_data/nodes.json" do
   content nodes.to_json
-  mode 0o644
+  mode "644"
   owner "root"
   group "root"
   notifies :run, "execute[/srv/hardware.openstreetmap.org]"
@@ -46,14 +46,14 @@ end
 
 file "/srv/hardware.openstreetmap.org/_data/roles.json" do
   content roles.to_json
-  mode 0o644
+  mode "644"
   owner "root"
   group "root"
   notifies :run, "execute[/srv/hardware.openstreetmap.org]"
 end
 
 directory "/srv/hardware.openstreetmap.org/_site" do
-  mode 0o755
+  mode "755"
   owner "nobody"
   group "nogroup"
 end

--- a/cookbooks/snmpd/metadata.rb
+++ b/cookbooks/snmpd/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Configures snmpd"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "networking"

--- a/cookbooks/snmpd/recipes/default.rb
+++ b/cookbooks/snmpd/recipes/default.rb
@@ -32,13 +32,13 @@ template "/etc/snmp/snmpd.conf" do
   source "snmpd.conf.erb"
   owner "root"
   group "root"
-  mode 0o600
+  mode "600"
   variables :communities => communities
   notifies :restart, "service[snmpd]"
 end
 
-if node[:snmpd][:clients]
-  node[:snmpd][:clients].each do |address|
+if node["snmpd"]["clients"]
+  node["snmpd"]["clients"].each do |address|
     firewall_rule "accept-snmp" do
       action :accept
       family "inet"

--- a/cookbooks/spamassassin/metadata.rb
+++ b/cookbooks/spamassassin/metadata.rb
@@ -3,6 +3,5 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures spamassassin"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"

--- a/cookbooks/spamassassin/recipes/default.rb
+++ b/cookbooks/spamassassin/recipes/default.rb
@@ -27,21 +27,21 @@ end
 directory "/var/spool/spamassassin" do
   owner "debian-spamd"
   group "debian-spamd"
-  mode 0o755
+  mode "755"
 end
 
 template "/etc/default/spamassassin" do
   source "spamassassin.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
   notifies :restart, "service[spamassassin]"
 end
 
-trusted_networks = node[:exim][:relay_from_hosts]
+trusted_networks = node["exim"]["relay_from_hosts"]
 
-if node[:exim][:smarthost_name]
-  search(:node, "exim_smarthost_via:#{node[:exim][:smarthost_name]}\\:*").each do |host|
+if node["exim"]["smarthost_name"]
+  search(:node, "exim_smarthost_via:#{node['exim']['smarthost_name']}\\:*").each do |host|
     trusted_networks |= host.ipaddresses(:role => :external)
   end
 end
@@ -52,7 +52,7 @@ template "/etc/spamassassin/local.cf" do
   source "local.cf.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
   variables :trusted_networks => trusted_networks.sort
   notifies :restart, "service[spamassassin]"
 end

--- a/cookbooks/squid/attributes/default.rb
+++ b/cookbooks/squid/attributes/default.rb
@@ -3,4 +3,4 @@ default[:squid][:cache_mem] = "256 MB"
 default[:squid][:cache_dir] = "ufs /var/spool/squid 256 16 256"
 default[:squid][:access_log] = "/var/log/squid/access.log openstreetmap"
 
-default[:apt][:sources] = node[:apt][:sources] | ["squid#{node[:squid][:version]}"]
+default[:apt][:sources] = node["apt"]["sources"] | ["squid#{node['squid']['version']}"]

--- a/cookbooks/squid/metadata.rb
+++ b/cookbooks/squid/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures squid"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "systemd"

--- a/cookbooks/squid/recipes/default.rb
+++ b/cookbooks/squid/recipes/default.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-if node[:squid][:version] >= 3
+if node["squid"]["version"] >= 3
   apt_package "squid" do
     action :unlock
   end
@@ -53,16 +53,16 @@ template "/etc/squid/squid.conf" do
   source "squid.conf.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
 end
 
 directory "/etc/squid/squid.conf.d" do
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end
 
-Array(node[:squid][:cache_dir]).each do |cache_dir|
+Array(node["squid"]["cache_dir"]).each do |cache_dir|
   if cache_dir =~ /^coss (\S+) /
     cache_dir = File.dirname(Regexp.last_match(1))
   elsif cache_dir =~ /^\S+ (\S+) /
@@ -72,7 +72,7 @@ Array(node[:squid][:cache_dir]).each do |cache_dir|
   directory cache_dir do
     owner "proxy"
     group "proxy"
-    mode 0o750
+    mode "750"
     recursive true
     notifies :restart, "service[squid]"
   end

--- a/cookbooks/squid/resources/fragment.rb
+++ b/cookbooks/squid/resources/fragment.rb
@@ -28,7 +28,7 @@ action :create do
     source new_resource.template
     owner "root"
     group "root"
-    mode 0o644
+    mode "644"
     variables new_resource.variables
   end
 end

--- a/cookbooks/ssl/metadata.rb
+++ b/cookbooks/ssl/metadata.rb
@@ -3,6 +3,5 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures basic SSL support"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"

--- a/cookbooks/ssl/recipes/default.rb
+++ b/cookbooks/ssl/recipes/default.rb
@@ -23,12 +23,12 @@ package "ssl-cert"
 cookbook_file "/etc/ssl/certs/letsencrypt.pem" do
   owner "root"
   group "root"
-  mode 0o444
+  mode "444"
   backup false
 end
 
 openssl_dhparam "/etc/ssl/certs/dhparam.pem" do
   owner "root"
   group "root"
-  mode 0o444
+  mode "444"
 end

--- a/cookbooks/ssl/resources/certificate.rb
+++ b/cookbooks/ssl/resources/certificate.rb
@@ -23,7 +23,7 @@ property :certificate, String, :name_property => true
 property :domains, [String, Array], :required => true
 
 action :create do
-  node.default[:letsencrypt][:certificates][new_resource.certificate] = {
+  node.default["letsencrypt"]["certificates"][new_resource.certificate] = {
     :domains => Array(new_resource.domains)
   }
 
@@ -36,7 +36,7 @@ action :create do
     file "/etc/ssl/certs/#{new_resource.certificate}.pem" do
       owner "root"
       group "root"
-      mode 0o444
+      mode "444"
       content certificate
       backup false
       manage_symlink_source false
@@ -46,7 +46,7 @@ action :create do
     file "/etc/ssl/private/#{new_resource.certificate}.key" do
       owner "root"
       group "ssl-cert"
-      mode 0o440
+      mode "440"
       content key
       backup false
       manage_symlink_source false
@@ -59,7 +59,7 @@ action :create do
       key_file "/etc/ssl/private/#{new_resource.certificate}.key"
       owner "root"
       group "ssl-cert"
-      mode 0o640
+      mode "640"
       org "OpenStreetMap"
       email "operations@osmfoundation.org"
       common_name new_resource.domains.first

--- a/cookbooks/stateofthemap/metadata.rb
+++ b/cookbooks/stateofthemap/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures State of the Map services"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "wordpress"

--- a/cookbooks/stateofthemap/recipes/default.rb
+++ b/cookbooks/stateofthemap/recipes/default.rb
@@ -44,7 +44,7 @@ end
 directory "/srv/2007.stateofthemap.org" do
   owner "wordpress"
   group "wordpress"
-  mode 0o755
+  mode "755"
 end
 
 wordpress_site "2007.stateofthemap.org" do
@@ -71,7 +71,7 @@ end
 directory "/srv/2008.stateofthemap.org" do
   owner "wordpress"
   group "wordpress"
-  mode 0o755
+  mode "755"
 end
 
 wordpress_site "2008.stateofthemap.org" do
@@ -98,7 +98,7 @@ end
 directory "/srv/2009.stateofthemap.org" do
   owner "wordpress"
   group "wordpress"
-  mode 0o755
+  mode "755"
 end
 
 git "/srv/2009.stateofthemap.org" do
@@ -135,7 +135,7 @@ end
 directory "/srv/2010.stateofthemap.org" do
   owner "wordpress"
   group "wordpress"
-  mode 0o755
+  mode "755"
 end
 
 git "/srv/2010.stateofthemap.org" do
@@ -176,7 +176,7 @@ end
 directory "/srv/2011.stateofthemap.org" do
   owner "wordpress"
   group "wordpress"
-  mode 0o755
+  mode "755"
 end
 
 git "/srv/2011.stateofthemap.org" do
@@ -217,7 +217,7 @@ end
 directory "/srv/2012.stateofthemap.org" do
   owner "wordpress"
   group "wordpress"
-  mode 0o755
+  mode "755"
 end
 
 git "/srv/2012.stateofthemap.org" do
@@ -293,7 +293,7 @@ gem_package "jekyll"
   end
 
   directory "/srv/#{year}.stateofthemap.org/_site" do
-    mode 0o755
+    mode "755"
     owner "nobody"
     group "nogroup"
   end
@@ -322,6 +322,6 @@ template "/etc/cron.daily/sotm-backup" do
   source "backup.cron.erb"
   owner "root"
   group "root"
-  mode 0o750
+  mode "750"
   variables :passwords => passwords
 end

--- a/cookbooks/subversion/metadata.rb
+++ b/cookbooks/subversion/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures subversion servers"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "apache"

--- a/cookbooks/subversion/recipes/default.rb
+++ b/cookbooks/subversion/recipes/default.rb
@@ -27,7 +27,7 @@ remote_directory "#{repository_directory}/hooks" do
   source "hooks"
   owner "www-data"
   group "www-data"
-  mode 0o755
+  mode "755"
   files_owner "www-data"
   files_group "www-data"
   files_mode 0o755
@@ -65,5 +65,5 @@ template "/etc/cron.daily/svn-backup" do
   source "backup.cron.erb"
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end

--- a/cookbooks/supybot/metadata.rb
+++ b/cookbooks/supybot/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures supybot"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "systemd"

--- a/cookbooks/supybot/recipes/default.rb
+++ b/cookbooks/supybot/recipes/default.rb
@@ -26,14 +26,14 @@ package "python-git"
 directory "/etc/supybot" do
   owner "supybot"
   group "supybot"
-  mode 0o755
+  mode "755"
 end
 
 template "/etc/supybot/supybot.conf" do
   source "supybot.conf.erb"
   owner "supybot"
   group "supybot"
-  mode 0o644
+  mode "644"
   variables :passwords => passwords
 end
 
@@ -41,78 +41,78 @@ template "/etc/supybot/channels.conf" do
   source "channels.conf.erb"
   owner "supybot"
   group "supybot"
-  mode 0o644
+  mode "644"
 end
 
 template "/etc/supybot/git.conf" do
   source "git.conf.erb"
   owner "supybot"
   group "supybot"
-  mode 0o644
+  mode "644"
 end
 
 template "/etc/supybot/ignores.conf" do
   source "ignores.conf.erb"
   owner "supybot"
   group "supybot"
-  mode 0o644
+  mode "644"
 end
 
 template "/etc/supybot/userdata.conf" do
   source "userdata.conf.erb"
   owner "supybot"
   group "supybot"
-  mode 0o644
+  mode "644"
 end
 
 template "/etc/supybot/users.conf" do
   source "users.conf.erb"
   owner "supybot"
   group "supybot"
-  mode 0o644
+  mode "644"
   variables :passwords => users
 end
 
 directory "/var/lib/supybot" do
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end
 
 directory "/var/lib/supybot/data" do
   owner "supybot"
   group "supybot"
-  mode 0o755
+  mode "755"
 end
 
 directory "/var/lib/supybot/backup" do
   owner "supybot"
   group "supybot"
-  mode 0o755
+  mode "755"
 end
 
 directory "/var/lib/supybot/git" do
   owner "supybot"
   group "supybot"
-  mode 0o755
+  mode "755"
 end
 
 directory "/var/log/supybot" do
   owner "supybot"
   group "supybot"
-  mode 0o755
+  mode "755"
 end
 
 directory "/usr/local/lib/supybot" do
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end
 
 directory "/usr/local/lib/supybot/plugins" do
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end
 
 git "/usr/local/lib/supybot/plugins/Git" do

--- a/cookbooks/switch2osm/metadata.rb
+++ b/cookbooks/switch2osm/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures servers for switch2osm"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "wordpress"

--- a/cookbooks/switch2osm/recipes/default.rb
+++ b/cookbooks/switch2osm/recipes/default.rb
@@ -82,6 +82,6 @@ template "/etc/cron.daily/switch2osm-backup" do
   source "backup.cron.erb"
   owner "root"
   group "root"
-  mode 0o750
+  mode "750"
   variables :passwords => passwords
 end

--- a/cookbooks/sysctl/metadata.rb
+++ b/cookbooks/sysctl/metadata.rb
@@ -3,6 +3,5 @@ maintainer       "Tom Hughes"
 maintainer_email "tom@compton.nu"
 license          "Apache-2.0"
 description      "Configures kernel parameters"
-long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version          "0.1"
 supports         "ubuntu"

--- a/cookbooks/sysctl/recipes/default.rb
+++ b/cookbooks/sysctl/recipes/default.rb
@@ -17,8 +17,8 @@
 # limitations under the License.
 #
 
-if node[:virtualization][:role] == "guest" &&
-   node[:virtualization][:system] == "lxd"
+if node["virtualization"]["role"] == "guest" &&
+   node["virtualization"]["system"] == "lxd"
   file "/etc/sysctl.d/60-chef.conf" do
     action :delete
   end
@@ -28,7 +28,7 @@ else
   directory "/etc/sysctl.d" do
     owner "root"
     group "root"
-    mode 0o755
+    mode "755"
   end
 
   execute "sysctl" do
@@ -40,11 +40,11 @@ else
     source "chef.conf.erb"
     owner "root"
     group "root"
-    mode 0o644
+    mode "644"
     notifies :run, "execute[sysctl]"
   end
 
-  node[:sysctl].each_value do |group|
+  node["sysctl"].each_value do |group|
     group[:parameters].each do |key, value|
       sysctl_file = "/proc/sys/#{key.tr('.', '/')}"
 

--- a/cookbooks/sysfs/metadata.rb
+++ b/cookbooks/sysfs/metadata.rb
@@ -3,6 +3,5 @@ maintainer       "Tom Hughes"
 maintainer_email "tom@compton.nu"
 license          "Apache-2.0"
 description      "Configures kernel parameters"
-long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version          "1.0.0"
 supports         "ubuntu"

--- a/cookbooks/sysfs/recipes/default.rb
+++ b/cookbooks/sysfs/recipes/default.rb
@@ -17,8 +17,8 @@
 # limitations under the License.
 #
 
-if node[:virtualization][:role] == "guest" &&
-   node[:virtualization][:system] == "lxd"
+if node["virtualization"]["role"] == "guest" &&
+   node["virtualization"]["system"] == "lxd"
   package "sysfsutils" do
     action :purge
   end
@@ -34,11 +34,11 @@ else
     source "sysfs.conf.erb"
     owner "root"
     group "root"
-    mode 0o644
+    mode "644"
     notifies :restart, "service[sysfsutils]"
   end
 
-  node[:sysfs].each_value do |group|
+  node["sysfs"].each_value do |group|
     group[:parameters].each do |key, value|
       sysfs_file = "/sys/#{key}"
 

--- a/cookbooks/systemd/metadata.rb
+++ b/cookbooks/systemd/metadata.rb
@@ -3,6 +3,5 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures systemd units"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"

--- a/cookbooks/systemd/resources/path.rb
+++ b/cookbooks/systemd/resources/path.rb
@@ -40,7 +40,7 @@ action :create do
     source "path.erb"
     owner "root"
     group "root"
-    mode 0o644
+    mode "644"
     variables path_variables
   end
 

--- a/cookbooks/systemd/resources/service.rb
+++ b/cookbooks/systemd/resources/service.rb
@@ -75,7 +75,7 @@ action :create do
       source "environment.erb"
       owner "root"
       group "root"
-      mode 0o640
+      mode "640"
       variables :environment => new_resource.environment_file
     end
 
@@ -86,7 +86,7 @@ action :create do
     directory dropin_directory do
       owner "root"
       group "root"
-      mode 0o755
+      mode "755"
     end
   end
 
@@ -95,7 +95,7 @@ action :create do
     source "service.erb"
     owner "root"
     group "root"
-    mode 0o644
+    mode "644"
     variables service_variables
     notifies :run, "execute[systemctl-reload]"
   end

--- a/cookbooks/systemd/resources/timer.rb
+++ b/cookbooks/systemd/resources/timer.rb
@@ -44,7 +44,7 @@ action :create do
     source "timer.erb"
     owner "root"
     group "root"
-    mode 0o644
+    mode "644"
     variables timer_variables
   end
 

--- a/cookbooks/systemd/resources/tmpfile.rb
+++ b/cookbooks/systemd/resources/tmpfile.rb
@@ -33,7 +33,7 @@ action :create do
     source "tmpfile.erb"
     owner "root"
     group "root"
-    mode 0o644
+    mode "644"
     variables new_resource.to_hash
   end
 

--- a/cookbooks/taginfo/metadata.rb
+++ b/cookbooks/taginfo/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures taginfo"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "apache"

--- a/cookbooks/taginfo/recipes/default.rb
+++ b/cookbooks/taginfo/recipes/default.rb
@@ -48,7 +48,7 @@ package %w[
   pbzip2
 ]
 
-ruby_version = node[:passenger][:ruby_version]
+ruby_version = node["passenger"]["ruby_version"]
 
 package "ruby#{ruby_version}"
 
@@ -65,17 +65,17 @@ apache_module "headers"
 directory "/var/log/taginfo" do
   owner "taginfo"
   group "taginfo"
-  mode 0o755
+  mode "755"
 end
 
 template "/etc/sudoers.d/taginfo" do
   source "sudoers.erb"
   owner "root"
   group "root"
-  mode 0o440
+  mode "440"
 end
 
-node[:taginfo][:sites].each do |site|
+node["taginfo"]["sites"].each do |site|
   site_name = site[:name]
   site_aliases = Array(site[:aliases])
   directory = site[:directory] || "/srv/#{site_name}"
@@ -87,13 +87,13 @@ node[:taginfo][:sites].each do |site|
   directory "/var/log/taginfo/#{site_name}" do
     owner "taginfo"
     group "taginfo"
-    mode 0o755
+    mode "755"
   end
 
   directory directory do
     owner "taginfo"
     group "taginfo"
-    mode 0o755
+    mode "755"
   end
 
   git "#{directory}/taginfo" do
@@ -128,7 +128,7 @@ node[:taginfo][:sites].each do |site|
   file "#{directory}/taginfo-config.json" do
     owner "taginfo"
     group "taginfo"
-    mode 0o644
+    mode "644"
     content settings
     notifies :restart, "service[apache2]"
   end
@@ -160,7 +160,7 @@ node[:taginfo][:sites].each do |site|
     directory "#{directory}/#{dir}" do
       owner "taginfo"
       group "taginfo"
-      mode 0o755
+      mode "755"
     end
   end
 
@@ -168,7 +168,7 @@ node[:taginfo][:sites].each do |site|
     source "update.erb"
     owner "taginfo"
     group "taginfo"
-    mode 0o755
+    mode "755"
     variables :name => site_name, :directory => directory
   end
 
@@ -192,6 +192,6 @@ template "/usr/local/bin/taginfo-update" do
   source "taginfo-update.erb"
   owner "root"
   group "root"
-  mode 0o755
-  variables :sites => node[:taginfo][:sites]
+  mode "755"
+  variables :sites => node["taginfo"]["sites"]
 end

--- a/cookbooks/tile/metadata.rb
+++ b/cookbooks/tile/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures tile servers"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "apache"

--- a/cookbooks/tile/recipes/default.rb
+++ b/cookbooks/tile/recipes/default.rb
@@ -38,8 +38,8 @@ apache_module "tile" do
   conf "tile.conf.erb"
 end
 
-ssl_certificate node[:fqdn] do
-  domains [node[:fqdn], "tile.openstreetmap.org", "render.openstreetmap.org"]
+ssl_certificate node["fqdn"] do
+  domains [node["fqdn"], "tile.openstreetmap.org", "render.openstreetmap.org"]
   notifies :reload, "service[apache2]"
 end
 
@@ -58,13 +58,13 @@ template "/etc/logrotate.d/apache2" do
   source "logrotate.apache.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
 end
 
 directory "/srv/tile.openstreetmap.org" do
   owner "tile"
   group "tile"
-  mode 0o755
+  mode "755"
 end
 
 package "renderd"
@@ -94,14 +94,14 @@ end
 directory "/srv/tile.openstreetmap.org/tiles" do
   owner "tile"
   group "tile"
-  mode 0o755
+  mode "755"
 end
 
 template "/etc/renderd.conf" do
   source "renderd.conf.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
   notifies :reload, "service[apache2]"
   notifies :restart, "service[renderd]"
 end
@@ -110,7 +110,7 @@ remote_directory "/srv/tile.openstreetmap.org/html" do
   source "html"
   owner "tile"
   group "tile"
-  mode 0o755
+  mode "755"
   files_owner "tile"
   files_group "tile"
   files_mode 0o644
@@ -120,7 +120,7 @@ template "/srv/tile.openstreetmap.org/html/index.html" do
   source "index.html.erb"
   owner "tile"
   group "tile"
-  mode 0o644
+  mode "644"
 end
 
 package %w[
@@ -145,21 +145,21 @@ package %w[
     source "https://github.com/googlei18n/noto-fonts/raw/master/hinted/#{font}"
     owner "root"
     group "root"
-    mode 0o644
+    mode "644"
   end
 end
 
 directory "/srv/tile.openstreetmap.org/cgi-bin" do
   owner "tile"
   group "tile"
-  mode 0o755
+  mode "755"
 end
 
 template "/srv/tile.openstreetmap.org/cgi-bin/export" do
   source "export.erb"
   owner "tile"
   group "tile"
-  mode 0o755
+  mode "755"
   variables :blocks => blocks, :totp_key => web_passwords["totp_key"]
 end
 
@@ -167,25 +167,25 @@ template "/srv/tile.openstreetmap.org/cgi-bin/debug" do
   source "debug.erb"
   owner "tile"
   group "tile"
-  mode 0o755
+  mode "755"
 end
 
 template "/etc/cron.hourly/export" do
   source "export.cron.erb"
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end
 
 directory "/srv/tile.openstreetmap.org/data" do
   owner "tile"
   group "tile"
-  mode 0o755
+  mode "755"
 end
 
 package "mapnik-utils"
 
-node[:tile][:data].each_value do |data|
+node["tile"]["data"].each_value do |data|
   url = data[:url]
   file = "/srv/tile.openstreetmap.org/data/#{File.basename(url)}"
 
@@ -195,7 +195,7 @@ node[:tile][:data].each_value do |data|
     directory directory do
       owner "tile"
       group "tile"
-      mode 0o755
+      mode "755"
     end
   else
     directory = "/srv/tile.openstreetmap.org/data"
@@ -250,7 +250,7 @@ node[:tile][:data].each_value do |data|
     source url
     owner "tile"
     group "tile"
-    mode 0o644
+    mode "644"
     backup false
     notifies :run, "execute[#{file}]", :immediately
     notifies :restart, "service[renderd]"
@@ -276,10 +276,10 @@ end
 directory "/srv/tile.openstreetmap.org/styles" do
   owner "tile"
   group "tile"
-  mode 0o755
+  mode "755"
 end
 
-node[:tile][:styles].each do |name, details|
+node["tile"]["styles"].each do |name, details|
   style_directory = "/srv/tile.openstreetmap.org/styles/#{name}"
   tile_directory = "/srv/tile.openstreetmap.org/tiles/#{name}"
 
@@ -287,7 +287,7 @@ node[:tile][:styles].each do |name, details|
     source "update-lowzoom.erb"
     owner "root"
     group "root"
-    mode 0o755
+    mode "755"
     variables :style => name
   end
 
@@ -299,21 +299,21 @@ node[:tile][:styles].each do |name, details|
   directory tile_directory do
     owner "tile"
     group "tile"
-    mode 0o755
+    mode "755"
   end
 
   details[:tile_directories].each do |directory|
     directory directory[:name] do
       owner "www-data"
       group "www-data"
-      mode 0o755
+      mode "755"
     end
 
     directory[:min_zoom].upto(directory[:max_zoom]) do |zoom|
       directory "#{directory[:name]}/#{zoom}" do
         owner "www-data"
         group "www-data"
-        mode 0o755
+        mode "755"
       end
 
       link "#{tile_directory}/#{zoom}" do
@@ -328,7 +328,7 @@ node[:tile][:styles].each do |name, details|
     action :create_if_missing
     owner "tile"
     group "tile"
-    mode 0o444
+    mode "444"
   end
 
   git style_directory do
@@ -357,48 +357,48 @@ node[:tile][:styles].each do |name, details|
   end
 end
 
-postgresql_version = node[:tile][:database][:cluster].split("/").first
-postgis_version = node[:tile][:database][:postgis]
+postgresql_version = node["tile"]["database"]["cluster"].split("/").first
+postgis_version = node["tile"]["database"]["postgis"]
 
 package "postgis"
 package "postgresql-#{postgresql_version}-postgis-#{postgis_version}"
 
 postgresql_user "jburgess" do
-  cluster node[:tile][:database][:cluster]
+  cluster node["tile"]["database"]["cluster"]
   superuser true
 end
 
 postgresql_user "tomh" do
-  cluster node[:tile][:database][:cluster]
+  cluster node["tile"]["database"]["cluster"]
   superuser true
 end
 
 postgresql_user "tile" do
-  cluster node[:tile][:database][:cluster]
+  cluster node["tile"]["database"]["cluster"]
 end
 
 postgresql_user "www-data" do
-  cluster node[:tile][:database][:cluster]
+  cluster node["tile"]["database"]["cluster"]
 end
 
 postgresql_database "gis" do
-  cluster node[:tile][:database][:cluster]
+  cluster node["tile"]["database"]["cluster"]
   owner "tile"
 end
 
 postgresql_extension "postgis" do
-  cluster node[:tile][:database][:cluster]
+  cluster node["tile"]["database"]["cluster"]
   database "gis"
 end
 
 postgresql_extension "hstore" do
-  cluster node[:tile][:database][:cluster]
+  cluster node["tile"]["database"]["cluster"]
   database "gis"
 end
 
 %w[geography_columns planet_osm_nodes planet_osm_rels planet_osm_ways raster_columns raster_overviews spatial_ref_sys].each do |table|
   postgresql_table table do
-    cluster node[:tile][:database][:cluster]
+    cluster node["tile"]["database"]["cluster"]
     database "gis"
     owner "tile"
     permissions "tile" => :all
@@ -407,7 +407,7 @@ end
 
 %w[geometry_columns planet_osm_line planet_osm_point planet_osm_polygon planet_osm_roads].each do |table|
   postgresql_table table do
-    cluster node[:tile][:database][:cluster]
+    cluster node["tile"]["database"]["cluster"]
     database "gis"
     owner "tile"
     permissions "tile" => :all, "www-data" => :select
@@ -415,20 +415,20 @@ end
 end
 
 postgresql_munin "gis" do
-  cluster node[:tile][:database][:cluster]
+  cluster node["tile"]["database"]["cluster"]
   database "gis"
 end
 
-file node[:tile][:node_file] do
+file node["tile"]["node_file"] do
   owner "tile"
   group "www-data"
-  mode 0o660
+  mode "660"
 end
 
 directory "/var/log/tile" do
   owner "tile"
   group "tile"
-  mode 0o755
+  mode "755"
 end
 
 package %w[
@@ -443,7 +443,7 @@ remote_directory "/usr/local/bin" do
   source "bin"
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
   files_owner "root"
   files_group "root"
   files_mode 0o755
@@ -453,26 +453,26 @@ template "/usr/local/bin/expire-tiles" do
   source "expire-tiles.erb"
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end
 
 directory "/var/lib/replicate" do
   owner "tile"
   group "tile"
-  mode 0o755
+  mode "755"
 end
 
 directory "/var/lib/replicate/expire-queue" do
   owner "tile"
   group "www-data"
-  mode 0o775
+  mode "775"
 end
 
 template "/usr/local/bin/replicate" do
   source "replicate.erb"
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end
 
 systemd_service "expire-tiles" do
@@ -522,14 +522,14 @@ template "/etc/logrotate.d/replicate" do
   source "replicate.logrotate.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
 end
 
 template "/usr/local/bin/render-lowzoom" do
   source "render-lowzoom.erb"
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end
 
 systemd_service "render-lowzoom" do
@@ -564,10 +564,10 @@ template "/usr/local/bin/cleanup-tiles" do
   source "cleanup-tiles.erb"
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end
 
-tile_directories = node[:tile][:styles].collect do |_, style|
+tile_directories = node["tile"]["styles"].collect do |_, style|
   style[:tile_directories].collect { |directory| directory[:name] }
 end.flatten.sort.uniq
 
@@ -575,7 +575,7 @@ template "/etc/cron.d/cleanup-tiles" do
   source "cleanup-tiles.cron.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
   variables :directories => tile_directories
 end
 

--- a/cookbooks/tilecache/metadata.rb
+++ b/cookbooks/tilecache/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures a tile cache"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "ssl"

--- a/cookbooks/tilecache/recipes/default.rb
+++ b/cookbooks/tilecache/recipes/default.rb
@@ -83,7 +83,7 @@ template "/etc/logrotate.d/squid" do
   source "logrotate.squid.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
 end
 
 nginx_site "default" do
@@ -94,7 +94,7 @@ template "/usr/local/bin/nginx_generate_tilecache_qos_map" do
   source "nginx_generate_tilecache_qos_map.erb"
   owner "root"
   group "root"
-  mode 0o750
+  mode "750"
   variables :totp_key => web_passwords["totp_key"]
 end
 
@@ -102,7 +102,7 @@ template "/etc/cron.d/tilecache" do
   source "cron.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
 end
 
 execute "execute_nginx_generate_tilecache_qos_map" do
@@ -132,7 +132,7 @@ template "/etc/logrotate.d/nginx" do
   source "logrotate.nginx.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
 end
 
 tilerenders.each do |render|

--- a/cookbooks/tilelog/metadata.rb
+++ b/cookbooks/tilelog/metadata.rb
@@ -3,7 +3,6 @@ maintainer       "OpenStreetMap Administrators"
 maintainer_email "admins@openstreetmap.org"
 license          "Apache-2.0"
 description      "Installs and configures tile log analysis"
-long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version          "1.0.0"
 supports         "ubuntu"
 depends          "git"

--- a/cookbooks/tilelog/recipes/default.rb
+++ b/cookbooks/tilelog/recipes/default.rb
@@ -29,9 +29,9 @@ package %w[
   libboost-program-options-dev
 ]
 
-tilelog_source_directory = node[:tilelog][:source_directory]
-tilelog_input_directory = node[:tilelog][:input_directory]
-tilelog_output_directory = node[:tilelog][:output_directory]
+tilelog_source_directory = node["tilelog"]["source_directory"]
+tilelog_input_directory = node["tilelog"]["input_directory"]
+tilelog_output_directory = node["tilelog"]["output_directory"]
 
 # resources for building the tile analysis binary
 git tilelog_source_directory do
@@ -74,7 +74,7 @@ template "/usr/local/bin/tilelog" do
   source "tilelog.erb"
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
   variables :analyze_bin => "#{tilelog_source_directory}/openstreetmap-tile-analyze",
             :input_dir => tilelog_input_directory,
             :output_dir => tilelog_output_directory
@@ -84,7 +84,7 @@ template "/etc/cron.d/tilelog" do
   source "tilelog.cron.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
 end
 
 # resources related to the output of the analysis and where it
@@ -92,5 +92,5 @@ end
 directory tilelog_output_directory do
   user "www-data"
   group "www-data"
-  mode 0o755
+  mode "755"
 end

--- a/cookbooks/tools/metadata.rb
+++ b/cookbooks/tools/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs system administration tools"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "systemd"

--- a/cookbooks/tools/recipes/default.rb
+++ b/cookbooks/tools/recipes/default.rb
@@ -62,9 +62,9 @@ end
 systemd_service "cron-timezone" do
   service "cron"
   dropin "timezone"
-  environment "TZ" => node[:timezone]
+  environment "TZ" => node["timezone"]
   notifies :restart, "service[cron]"
-  only_if { node[:timezone] }
+  only_if { node["timezone"] }
 end
 
 # Make sure cron is running

--- a/cookbooks/trac/metadata.rb
+++ b/cookbooks/trac/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures trac servers"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "apache"

--- a/cookbooks/trac/recipes/default.rb
+++ b/cookbooks/trac/recipes/default.rb
@@ -32,7 +32,7 @@ template "/var/lib/trac/conf/trac.ini" do
   source "trac.ini.erb"
   owner "trac"
   group "www-data"
-  mode 0o644
+  mode "644"
   variables :name => site_name
 end
 
@@ -40,7 +40,7 @@ remote_directory "/var/lib/trac/htdocs" do
   source "htdocs"
   owner "trac"
   group "trac"
-  mode 0o755
+  mode "755"
   files_owner "trac"
   files_group "trac"
   files_mode 0o644
@@ -51,7 +51,7 @@ remote_directory "/var/lib/trac/templates" do
   source "templates"
   owner "trac"
   group "trac"
-  mode 0o755
+  mode "755"
   files_owner "trac"
   files_group "trac"
   files_mode 0o644
@@ -68,7 +68,7 @@ end
 cookbook_file "/usr/local/bin/trac-authenticate" do
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end
 
 apache_module "wsgi"
@@ -88,12 +88,12 @@ template "/etc/sudoers.d/trac" do
   source "sudoers.erb"
   owner "root"
   group "root"
-  mode 0o440
+  mode "440"
 end
 
 template "/etc/cron.daily/trac-backup" do
   source "backup.cron.erb"
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end

--- a/cookbooks/web/metadata.rb
+++ b/cookbooks/web/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures www.openstreetmap.org servers"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.1"
 supports          "ubuntu"
 depends           "apache"

--- a/cookbooks/web/recipes/backend.rb
+++ b/cookbooks/web/recipes/backend.rb
@@ -36,11 +36,11 @@ end
 
 apache_site "www.openstreetmap.org" do
   template "apache.backend.erb"
-  variables :status => node[:web][:status],
+  variables :status => node["web"]["status"],
             :secret_key_base => web_passwords["secret_key_base"]
 end
 
-node.normal[:memcached][:ip_address] = node.internal_ipaddress
+node.normal["memcached"][:ip_address] = node.internal_ipaddress
 
 service "rails-jobs@storage" do
   action [:enable, :start]
@@ -49,7 +49,7 @@ service "rails-jobs@storage" do
   subscribes :restart, "systemd_service[rails-jobs]"
 end
 
-if node[:web][:primary_cluster]
+if node["web"]["primary_cluster"]
   service "rails-jobs@traces" do
     action [:enable, :start]
     supports :restart => true

--- a/cookbooks/web/recipes/base.rb
+++ b/cookbooks/web/recipes/base.rb
@@ -17,34 +17,34 @@
 # limitations under the License.
 #
 
-node.default[:nfs]["/store/rails"] = {
-  :host => node[:web][:fileserver],
+node.default["nfs"]["/store/rails"] = {
+  :host => node["web"]["fileserver"],
   :path => "/store/rails"
 }
 
 include_recipe "nfs"
 
-directory node[:web][:base_directory] do
+directory node["web"]["base_directory"] do
   group "rails"
-  mode 0o2775
+  mode "2775"
 end
 
-systemd_tmpfile node[:web][:pid_directory] do
+systemd_tmpfile node["web"]["pid_directory"] do
   type "d"
   owner "rails"
   group "rails"
   mode "0755"
 end
 
-directory node[:web][:log_directory] do
+directory node["web"]["log_directory"] do
   owner "rails"
   group "rails"
-  mode 0o775
+  mode "775"
 end
 
 template "/etc/logrotate.d/web" do
   source "logrotate.web.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
 end

--- a/cookbooks/web/recipes/cgimap.rb
+++ b/cookbooks/web/recipes/cgimap.rb
@@ -26,15 +26,15 @@ package "openstreetmap-cgimap-bin" do
   action :upgrade
 end
 
-if node[:web][:readonly_database_host]
-  database_host = node[:web][:readonly_database_host]
+if node["web"]["readonly_database_host"]
+  database_host = node["web"]["readonly_database_host"]
   database_readonly = true
 else
-  database_host = node[:web][:database_host]
-  database_readonly = node[:web][:status] == "database_readonly"
+  database_host = node["web"]["database_host"]
+  database_readonly = node["web"]["status"] == "database_readonly"
 end
 
-memcached_servers = node[:web][:memcached_servers] || []
+memcached_servers = node["web"]["memcached_servers"] || []
 
 switches = database_readonly ? " --readonly" : ""
 
@@ -45,10 +45,10 @@ systemd_service "cgimap" do
                    "CGIMAP_DBNAME" => "openstreetmap",
                    "CGIMAP_USERNAME" => "cgimap",
                    "CGIMAP_PASSWORD" => db_passwords["cgimap"],
-                   "CGIMAP_OAUTH_HOST" => node[:web][:database_host],
-                   "CGIMAP_UPDATE_HOST" => node[:web][:database_host],
-                   "CGIMAP_PIDFILE" => "#{node[:web][:pid_directory]}/cgimap.pid",
-                   "CGIMAP_LOGFILE" => "#{node[:web][:log_directory]}/cgimap.log",
+                   "CGIMAP_OAUTH_HOST" => node["web"]["database_host"],
+                   "CGIMAP_UPDATE_HOST" => node["web"]["database_host"],
+                   "CGIMAP_PIDFILE" => "#{node['web']['pid_directory']}/cgimap.pid",
+                   "CGIMAP_LOGFILE" => "#{node['web']['log_directory']}/cgimap.log",
                    "CGIMAP_MEMCACHE" => memcached_servers.join(","),
                    "CGIMAP_RATELIMIT" => "204800",
                    "CGIMAP_MAXDEBT" => "250"
@@ -61,10 +61,10 @@ systemd_service "cgimap" do
   protect_home true
   no_new_privileges true
   restart "on-failure"
-  pid_file "#{node[:web][:pid_directory]}/cgimap.pid"
+  pid_file "#{node['web']['pid_directory']}/cgimap.pid"
 end
 
-if %w[database_offline api_offline].include?(node[:web][:status])
+if %w[database_offline api_offline].include?(node["web"]["status"])
   service "cgimap" do
     action :stop
   end

--- a/cookbooks/web/recipes/cleanup.rb
+++ b/cookbooks/web/recipes/cleanup.rb
@@ -19,13 +19,13 @@
 
 include_recipe "web::base"
 
-ruby = "ruby#{node[:passenger][:ruby_version]}"
-rails_directory = "#{node[:web][:base_directory]}/rails"
+ruby = "ruby#{node['passenger']['ruby_version']}"
+rails_directory = "#{node['web']['base_directory']}/rails"
 
 template "/etc/cron.daily/web-cleanup" do
   source "cleanup.cron.erb"
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
   variables :ruby => ruby, :directory => rails_directory
 end

--- a/cookbooks/web/recipes/frontend.rb
+++ b/cookbooks/web/recipes/frontend.rb
@@ -38,7 +38,7 @@ end
 
 apache_site "www.openstreetmap.org" do
   template "apache.frontend.erb"
-  variables :status => node[:web][:status],
+  variables :status => node["web"]["status"],
             :secret_key_base => web_passwords["secret_key_base"]
 end
 
@@ -46,7 +46,7 @@ template "/etc/logrotate.d/apache2" do
   source "logrotate.apache.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
 end
 
 service "rails-jobs@mailers" do

--- a/cookbooks/web/recipes/rails.rb
+++ b/cookbooks/web/recipes/rails.rb
@@ -44,11 +44,11 @@ template "/etc/cron.hourly/passenger" do
   source "passenger.cron.erb"
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end
 
-ruby_version = node[:passenger][:ruby_version]
-rails_directory = "#{node[:web][:base_directory]}/rails"
+ruby_version = node["passenger"]["ruby_version"]
+rails_directory = "#{node['web']['base_directory']}/rails"
 
 piwik = data_bag_item("web", "piwik")
 
@@ -74,18 +74,18 @@ rails_port "www.openstreetmap.org" do
   group "rails"
   repository "https://git.openstreetmap.org/public/rails.git"
   revision "live"
-  database_host node[:web][:database_host]
+  database_host node["web"]["database_host"]
   database_name "openstreetmap"
   database_username "rails"
   database_password db_passwords["rails"]
   email_from "OpenStreetMap <web@noreply.openstreetmap.org>"
-  status node[:web][:status]
+  status node["web"]["status"]
   messages_domain "messages.openstreetmap.org"
   gpx_dir "/store/rails/gpx"
   attachments_dir "/store/rails/attachments"
-  log_path "#{node[:web][:log_directory]}/rails.log"
-  logstash_path "#{node[:web][:log_directory]}/rails-logstash.log"
-  memcache_servers node[:web][:memcached_servers]
+  log_path "#{node['web']['log_directory']}/rails.log"
+  logstash_path "#{node['web']['log_directory']}/rails-logstash.log"
+  memcache_servers node["web"]["memcached_servers"]
   potlatch2_key web_passwords["potlatch2_key"]
   id_key web_passwords["id_key"]
   oauth_key web_passwords["oauth_key"]
@@ -134,7 +134,7 @@ template "/usr/local/bin/cleanup-rails-assets" do
   source "cleanup-assets.erb"
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end
 
 gem_package "apachelogregex"
@@ -144,7 +144,7 @@ template "/usr/local/bin/api-statistics" do
   source "api-statistics.erb"
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
 end
 
 systemd_service "api-statistics" do
@@ -173,10 +173,10 @@ gem_package "hpricot"
 munin_plugin "api_calls_status"
 munin_plugin "api_calls_num"
 
-munin_plugin "api_calls_#{node[:hostname]}" do
+munin_plugin "api_calls_#{node['hostname']}" do
   target "api_calls_"
 end
 
-munin_plugin "api_waits_#{node[:hostname]}" do
+munin_plugin "api_waits_#{node['hostname']}" do
   target "api_waits_"
 end

--- a/cookbooks/web/recipes/statistics.rb
+++ b/cookbooks/web/recipes/statistics.rb
@@ -19,14 +19,14 @@
 
 include_recipe "web::base"
 
-ruby = "ruby#{node[:passenger][:ruby_version]}"
-rails_directory = "#{node[:web][:base_directory]}/rails"
+ruby = "ruby#{node['passenger']['ruby_version']}"
+rails_directory = "#{node['web']['base_directory']}/rails"
 
 template "/usr/local/bin/statistics" do
   source "statistics.erb"
   owner "root"
   group "root"
-  mode 0o755
+  mode "755"
   variables :ruby => ruby, :directory => rails_directory
 end
 
@@ -34,5 +34,5 @@ template "/etc/cron.d/statistics" do
   source "statistics.cron.erb"
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
 end

--- a/cookbooks/web/resources/rails_port.rb
+++ b/cookbooks/web/resources/rails_port.rb
@@ -121,7 +121,7 @@ action :create do
   declare_resource :directory, rails_directory do
     owner new_resource.user
     group new_resource.group
-    mode 0o2775
+    mode "2775"
   end
 
   git rails_directory do
@@ -152,7 +152,7 @@ action :create do
     source "database.yml.erb"
     owner new_resource.user
     group new_resource.group
-    mode 0o664
+    mode "664"
     variables :host => new_resource.database_host,
               :port => new_resource.database_port,
               :name => new_resource.database_name,
@@ -277,7 +277,7 @@ action :create do
     path "#{rails_directory}/config/application.yml"
     owner new_resource.user
     group new_resource.group
-    mode 0o664
+    mode "664"
     content application_yml
     notifies :run, "execute[#{rails_directory}/public/assets]"
     only_if { ::File.exist?("#{rails_directory}/config/example.application.yml") }
@@ -341,7 +341,7 @@ action :create do
   file "#{rails_directory}/config/settings.local.yml" do
     owner new_resource.user
     group new_resource.group
-    mode 0o664
+    mode "664"
     content YAML.dump(settings)
     notifies :run, "execute[#{rails_directory}/public/assets]"
     only_if { ::File.exist?("#{rails_directory}/config/settings.yml") }
@@ -357,7 +357,7 @@ action :create do
   file "#{rails_directory}/config/storage.yml" do
     owner new_resource.user
     group new_resource.group
-    mode 0o664
+    mode "664"
     content YAML.dump(storage_configuration)
     notifies :run, "execute[#{rails_directory}/public/assets]"
   end
@@ -366,7 +366,7 @@ action :create do
     file "#{rails_directory}/config/piwik.yml" do
       owner new_resource.user
       group new_resource.group
-      mode 0o664
+      mode "664"
       content YAML.dump(new_resource.piwik_configuration)
       notifies :run, "execute[#{rails_directory}/public/assets]"
     end
@@ -433,7 +433,7 @@ action :create do
     source "rails.cron.erb"
     owner "root"
     group "root"
-    mode 0o755
+    mode "755"
     variables :directory => rails_directory
   end
 end

--- a/cookbooks/wiki/metadata.rb
+++ b/cookbooks/wiki/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures servers for wiki.openstreetmap.org"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "mediawiki"

--- a/cookbooks/wiki/recipes/default.rb
+++ b/cookbooks/wiki/recipes/default.rb
@@ -106,34 +106,34 @@ mediawiki_extension "MultiMaps" do
 end
 
 cookbook_file "/srv/wiki.openstreetmap.org/osm_logo_wiki.png" do
-  owner node[:mediawiki][:user]
-  group node[:mediawiki][:group]
-  mode 0o644
+  owner node["mediawiki"]["user"]
+  group node["mediawiki"]["group"]
+  mode "644"
 end
 
 template "/srv/wiki.openstreetmap.org/robots.txt" do
-  owner node[:mediawiki][:user]
-  group node[:mediawiki][:group]
-  mode 0o644
+  owner node["mediawiki"]["user"]
+  group node["mediawiki"]["group"]
+  mode "644"
   source "robots.txt.erb"
 end
 
 cookbook_file "/srv/wiki.openstreetmap.org/favicon.ico" do
-  owner node[:mediawiki][:user]
-  group node[:mediawiki][:group]
-  mode 0o644
+  owner node["mediawiki"]["user"]
+  group node["mediawiki"]["group"]
+  mode "644"
 end
 
 directory "/srv/wiki.openstreetmap.org/dump" do
-  owner node[:mediawiki][:user]
-  group node[:mediawiki][:group]
+  owner node["mediawiki"]["user"]
+  group node["mediawiki"]["group"]
   mode "0775"
 end
 
 template "/etc/cron.d/wiki-dump" do
   owner "root"
   group "root"
-  mode 0o644
+  mode "644"
   source "wiki-dump.erb"
   variables :directory => "/srv/wiki.openstreetmap.org"
 end

--- a/cookbooks/wordpress/metadata.rb
+++ b/cookbooks/wordpress/metadata.rb
@@ -3,7 +3,6 @@ maintainer        "OpenStreetMap Administrators"
 maintainer_email  "admins@openstreetmap.org"
 license           "Apache-2.0"
 description       "Installs and configures Wordpress"
-long_description  IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version           "1.0.0"
 supports          "ubuntu"
 depends           "apache"

--- a/cookbooks/wordpress/resources/plugin.rb
+++ b/cookbooks/wordpress/resources/plugin.rb
@@ -32,11 +32,11 @@ action :create do
     remote_directory plugin_directory do
       cookbook "wordpress"
       source new_resource.source
-      owner node[:wordpress][:user]
-      group node[:wordpress][:group]
-      mode 0o755
-      files_owner node[:wordpress][:user]
-      files_group node[:wordpress][:group]
+      owner node["wordpress"]["user"]
+      group node["wordpress"]["group"]
+      mode "755"
+      files_owner node["wordpress"]["user"]
+      files_group node["wordpress"]["group"]
       files_mode 0o755
     end
   else
@@ -47,15 +47,15 @@ action :create do
         action :sync
         repository plugin_repository
         revision new_resource.revision
-        user node[:wordpress][:user]
-        group node[:wordpress][:group]
+        user node["wordpress"]["user"]
+        group node["wordpress"]["group"]
       end
     else
       subversion plugin_directory do
         action :sync
         repository plugin_repository
-        user node[:wordpress][:user]
-        group node[:wordpress][:group]
+        user node["wordpress"]["user"]
+        group node["wordpress"]["group"]
         ignore_failure plugin_repository.start_with?("https://plugins.svn.wordpress.org/")
       end
     end
@@ -71,7 +71,7 @@ end
 
 action_class do
   def site_directory
-    node[:wordpress][:sites][new_resource.site][:directory]
+    node["wordpress"]["sites"][new_resource.site]["directory"]
   end
 
   def plugin_directory

--- a/cookbooks/wordpress/resources/site.rb
+++ b/cookbooks/wordpress/resources/site.rb
@@ -36,7 +36,7 @@ action :create do
 
   node.normal_unless[:wordpress][:sites][new_resource.site] = {}
 
-  node.normal[:wordpress][:sites][new_resource.site][:directory] = site_directory
+  node.normal["wordpress"]["sites"][new_resource.site][:directory] = site_directory
 
   node.normal_unless[:wordpress][:sites][new_resource.site][:auth_key] = SecureRandom.base64(48)
   node.normal_unless[:wordpress][:sites][new_resource.site][:secure_auth_key] = SecureRandom.base64(48)
@@ -56,16 +56,16 @@ action :create do
   end
 
   declare_resource :directory, site_directory do
-    owner node[:wordpress][:user]
-    group node[:wordpress][:group]
-    mode 0o755
+    owner node["wordpress"]["user"]
+    group node["wordpress"]["group"]
+    mode "755"
   end
 
   subversion site_directory do
     action :sync
     repository "https://core.svn.wordpress.org/tags/#{version}"
-    user node[:wordpress][:user]
-    group node[:wordpress][:group]
+    user node["wordpress"]["user"]
+    group node["wordpress"]["group"]
     ignore_failure true
   end
 
@@ -75,14 +75,14 @@ action :create do
     line.gsub!(/password_here/, new_resource.database_password)
     line.gsub!(/wp_/, new_resource.database_prefix)
 
-    line.gsub!(/('AUTH_KEY', *)'put your unique phrase here'/, "\\1'#{node[:wordpress][:sites][new_resource.site][:auth_key]}'")
-    line.gsub!(/('SECURE_AUTH_KEY', *)'put your unique phrase here'/, "\\1'#{node[:wordpress][:sites][new_resource.site][:secure_auth_key]}'")
-    line.gsub!(/('LOGGED_IN_KEY', *)'put your unique phrase here'/, "\\1'#{node[:wordpress][:sites][new_resource.site][:logged_in_key]}'")
-    line.gsub!(/('NONCE_KEY', *)'put your unique phrase here'/, "\\1'#{node[:wordpress][:sites][new_resource.site][:nonce_key]}'")
-    line.gsub!(/('AUTH_SALT', *)'put your unique phrase here'/, "\\1'#{node[:wordpress][:sites][new_resource.site][:auth_salt]}'")
-    line.gsub!(/('SECURE_AUTH_SALT', *)'put your unique phrase here'/, "\\1'#{node[:wordpress][:sites][new_resource.site][:secure_auth_salt]}'")
-    line.gsub!(/('LOGGED_IN_SALT', *)'put your unique phrase here'/, "\\1'#{node[:wordpress][:sites][new_resource.site][:logged_in_salt]}'")
-    line.gsub!(/('NONCE_SALT', *)'put your unique phrase here'/, "\\1'#{node[:wordpress][:sites][new_resource.site][:nonce_salt]}'")
+    line.gsub!(/('AUTH_KEY', *)'put your unique phrase here'/, "\\1'#{node['wordpress']['sites'][new_resource.site]['auth_key']}'")
+    line.gsub!(/('SECURE_AUTH_KEY', *)'put your unique phrase here'/, "\\1'#{node['wordpress']['sites'][new_resource.site]['secure_auth_key']}'")
+    line.gsub!(/('LOGGED_IN_KEY', *)'put your unique phrase here'/, "\\1'#{node['wordpress']['sites'][new_resource.site]['logged_in_key']}'")
+    line.gsub!(/('NONCE_KEY', *)'put your unique phrase here'/, "\\1'#{node['wordpress']['sites'][new_resource.site]['nonce_key']}'")
+    line.gsub!(/('AUTH_SALT', *)'put your unique phrase here'/, "\\1'#{node['wordpress']['sites'][new_resource.site]['auth_salt']}'")
+    line.gsub!(/('SECURE_AUTH_SALT', *)'put your unique phrase here'/, "\\1'#{node['wordpress']['sites'][new_resource.site]['secure_auth_salt']}'")
+    line.gsub!(/('LOGGED_IN_SALT', *)'put your unique phrase here'/, "\\1'#{node['wordpress']['sites'][new_resource.site]['logged_in_salt']}'")
+    line.gsub!(/('NONCE_SALT', *)'put your unique phrase here'/, "\\1'#{node['wordpress']['sites'][new_resource.site]['nonce_salt']}'")
 
     if line =~ /define\('WP_DEBUG'/
       line += "\n"
@@ -98,16 +98,16 @@ action :create do
   end
 
   file "#{site_directory}/wp-config.php" do
-    owner node[:wordpress][:user]
-    group node[:wordpress][:group]
-    mode 0o644
+    owner node["wordpress"]["user"]
+    group node["wordpress"]["group"]
+    mode "644"
     content wp_config
   end
 
   declare_resource :directory, "#{site_directory}/wp-content/uploads" do
     owner "www-data"
     group "www-data"
-    mode 0o755
+    mode "755"
   end
 
   file "#{site_directory}/sitemap.xml" do
@@ -120,9 +120,9 @@ action :create do
 
   cookbook_file "#{site_directory}/googlefac54c35e800caab.html" do
     cookbook "wordpress"
-    owner node[:wordpress][:user]
-    group node[:wordpress][:group]
-    mode 0o644
+    owner node["wordpress"]["user"]
+    group node["wordpress"]["group"]
+    mode "644"
     backup false
   end
 

--- a/cookbooks/wordpress/resources/theme.rb
+++ b/cookbooks/wordpress/resources/theme.rb
@@ -32,11 +32,11 @@ action :create do
     remote_directory theme_directory do
       cookbook "wordpress"
       source new_resource.source
-      owner node[:wordpress][:user]
-      group node[:wordpress][:group]
-      mode 0o755
-      files_owner node[:wordpress][:user]
-      files_group node[:wordpress][:group]
+      owner node["wordpress"]["user"]
+      group node["wordpress"]["group"]
+      mode "755"
+      files_owner node["wordpress"]["user"]
+      files_group node["wordpress"]["group"]
       files_mode 0o644
     end
   else
@@ -47,15 +47,15 @@ action :create do
         action :sync
         repository theme_repository
         revision new_resource.revision
-        user node[:wordpress][:user]
-        group node[:wordpress][:group]
+        user node["wordpress"]["user"]
+        group node["wordpress"]["group"]
       end
     else
       subversion theme_directory do
         action :sync
         repository theme_repository
-        user node[:wordpress][:user]
-        group node[:wordpress][:group]
+        user node["wordpress"]["user"]
+        group node["wordpress"]["group"]
         ignore_failure theme_repository.start_with?("https://themes.svn.wordpress.org/")
       end
     end
@@ -71,7 +71,7 @@ end
 
 action_class do
   def site_directory
-    node[:wordpress][:sites][new_resource.site][:directory]
+    node["wordpress"]["sites"][new_resource.site]["directory"]
   end
 
   def theme_directory


### PR DESCRIPTION
Chef specific rules are being added to Cookstyle to replace Foodcritic as the single Ruby + Chef linter in the Chef ecosystem. I ran the current master of Cookstyle over this repo with autocorrect enabled.

What changed
- Removed the unused long_description metadata from cookbook metadata.rb
- Converted all node attributes from symbols to strings
- Converted file modes to strings

Signed-off-by: Tim Smith <tsmith@chef.io>