### PR TITLE
after MW upgrade sysops unable to edit MW UI

### DIFF
--- a/cookbooks/mediawiki/templates/default/LocalSettings.php.erb
+++ b/cookbooks/mediawiki/templates/default/LocalSettings.php.erb
@@ -209,6 +209,10 @@ $wgWhitelistRead = array ("Special:Userlogin");
 # Prevent new user registrations except by sysops
 $wgGroupPermissions['*']['createaccount'] = false;
 
+# Since 1.32 MW introduced interface-admin group to separate all UI-related rights. This makes sense for bigger sites,
+# but for OSM it makes more sense to keep group structure simple.  Give all interface-admin rights to sysops.
+$wgGroupPermissions['sysop'] = array_merge($wgGroupPermissions['sysop'], $wgGroupPermissions['interface-admin']);
+
 # Restrict access to the upload directory
 $wgUploadPath = "$wgScriptPath/img_auth.php";
 <% end -%>

--- a/cookbooks/mediawiki/templates/default/LocalSettings.php.erb
+++ b/cookbooks/mediawiki/templates/default/LocalSettings.php.erb
@@ -211,7 +211,14 @@ $wgGroupPermissions['*']['createaccount'] = false;
 
 # Since 1.32 MW introduced interface-admin group to separate all UI-related rights. This makes sense for bigger sites,
 # but for OSM it makes more sense to keep group structure simple.  Give all interface-admin rights to sysops.
-$wgGroupPermissions['sysop'] = array_merge($wgGroupPermissions['sysop'], $wgGroupPermissions['interface-admin']);
+# Also remove the interface-admin group to avoid confusion.
+$wgGroupPermissions['sysop'] = array_merge( $wgGroupPermissions['sysop'], $wgGroupPermissions['interface-admin'] );
+unset( $wgGroupPermissions['interface-admin'] );
+unset( $wgRevokePermissions['interface-admin'] );
+unset( $wgAddGroups['interface-admin'] );
+unset( $wgRemoveGroups['interface-admin'] );
+unset( $wgGroupsAddToSelf['interface-admin'] );
+unset( $wgGroupsRemoveFromSelf['interface-admin'] );
 
 # Restrict access to the upload directory
 $wgUploadPath = "$wgScriptPath/img_auth.php";


### PR DESCRIPTION
the new version moved UI-editing rights out of sysop and its own group because large wikis may have too big of a non-techy admin community (thousands). It would be pointless for a small wiki like ours.