### PR TITLE
enable gadgets-edit rights to sysops

### DIFF
--- a/cookbooks/mediawiki/templates/default/LocalSettings.php.erb
+++ b/cookbooks/mediawiki/templates/default/LocalSettings.php.erb
@@ -204,6 +204,11 @@ unset( $wgRemoveGroups['interface-admin'] );
 unset( $wgGroupsAddToSelf['interface-admin'] );
 unset( $wgGroupsRemoveFromSelf['interface-admin'] );
 
+# The v1.32+ gadget system also requires two additional rights
+# See https://www.mediawiki.org/wiki/Extension:Gadgets
+$wgGroupPermissions['sysop']['gadgets-edit'] = true;
+$wgGroupPermissions['sysop']['gadgets-definition-edit'] = true;
+
 <% if @mediawiki[:private_accounts] -%>
 # Prevent new user registrations except by existing users
 $wgGroupPermissions['*']['createaccount'] = false;


### PR DESCRIPTION
another issues with the new way gadgets are being used - need an extra right for sysops explicitly declared.