### PR TITLE
Increase nginx keepalive settings.

### DIFF
--- a/cookbooks/tilecache/templates/default/nginx_tile.conf.erb
+++ b/cookbooks/tilecache/templates/default/nginx_tile.conf.erb
@@ -15,7 +15,8 @@ upstream tile_cache_backend {
 <% end -%>
 <% end -%>
 
-  keepalive 256;
+  keepalive 1024;
+  keepalive_requests 1024;
 }
 
 # Geo Map of tile caches


### PR DESCRIPTION
Increase both the number of requests per keepalive connection and the number of keepalive connections to retain. This should reduce the number of sockets used for a single connection and therefore make it less likely that nginx will experience ephemeral socket exhaustion at high request rates.

This is related to https://github.com/openstreetmap/operations/issues/335 and, while it won't fix the root cause issue (hardware failure), it might help.
