### PR TITLE
Fixed small bugs after trying wiki test-kitchen

### DIFF
--- a/.github/workflows/test-kitchen.yml
+++ b/.github/workflows/test-kitchen.yml
@@ -92,6 +92,7 @@ jobs:
           - web-frontend
           - web-rails
           - wordpress
+          - wiki
         os:
           - ubuntu-1804
       fail-fast: false

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -323,3 +323,10 @@ suites:
   - name: wordpress
     run_list:
       - recipe[wordpress::default]
+  - name: wiki
+    run_list:
+      - recipe[apt::default]
+      - recipe[accounts::default]
+      - recipe[munin::default]
+      - recipe[wiki]
+      - role[wiki]

--- a/cookbooks/mediawiki/resources/site.rb
+++ b/cookbooks/mediawiki/resources/site.rb
@@ -397,6 +397,8 @@ action :create do
   mediawiki_extension "CheckUser" do
     site new_resource.site
     template "mw-ext-CheckUser.inc.php.erb"
+    repository "git://github.com/migurski/extension-checkuser.git"
+    reference "0fe3015e57bb6ee771ecaebf3b2d79a251bd4e3a"
     update_site false
   end
 

--- a/cookbooks/mediawiki/resources/site.rb
+++ b/cookbooks/mediawiki/resources/site.rb
@@ -398,7 +398,7 @@ action :create do
     site new_resource.site
     template "mw-ext-CheckUser.inc.php.erb"
     repository "git://github.com/migurski/extension-checkuser.git"
-    reference "0fe3015e57bb6ee771ecaebf3b2d79a251bd4e3a"
+    reference "0e3bf4aa3d05b60240b0abc1a00d87c9fc4c5cf7"
     update_site false
   end
 

--- a/cookbooks/mediawiki/resources/site.rb
+++ b/cookbooks/mediawiki/resources/site.rb
@@ -397,8 +397,6 @@ action :create do
   mediawiki_extension "CheckUser" do
     site new_resource.site
     template "mw-ext-CheckUser.inc.php.erb"
-    repository "git://github.com/migurski/extension-checkuser.git"
-    reference "0e3bf4aa3d05b60240b0abc1a00d87c9fc4c5cf7"
     update_site false
   end
 

--- a/test/data_bags/accounts/wiki.json
+++ b/test/data_bags/accounts/wiki.json
@@ -1,0 +1,7 @@
+{
+  "id": "wiki",
+  "uid": "555",
+  "comment": "wiki.openstreetmap.org",
+  "home": "/opt/wiki",
+  "manage_home": false
+}

--- a/test/data_bags/wiki/passwords.json
+++ b/test/data_bags/wiki/passwords.json
@@ -1,0 +1,6 @@
+{
+  "database": "pw1",
+  "admin": "pw2",
+  "recaptcha": "pw3",
+  "thunderforest": "pw4"
+}


### PR DESCRIPTION
- Updated Ubuntu from 16.04 to 18.04 based on [current running hardware](https://hardware.openstreetmap.org)
- ~~Added Mediwaiki Apt repository to support Parsoid install~~ Added `apt` as `mediawiki` dependency to complete installation
- ~~Added missing Wiki user account~~ Added `accounts` as `mediawiki` dependency to complete installation
- Added dummy passwords in test data bag

Test plan:
---
1. Add test kitchen configuration like:

          - name: migurski_testing
            run_list:
              - recipe[munin]
              - recipe[wiki]
              - role[wiki]

2. Run `kitchen converge migurski-testing-ubuntu-1804`

Result
---
Still seeing some late-stage failures detailed in this log, but gets further than previously: https://gist.github.com/migurski/e08c0207d18462258498b198f1ae3607
