### PR TITLE
Updated Mediawiki apt repo signing key to current value

### DIFF
--- a/cookbooks/apt/recipes/default.rb
+++ b/cookbooks/apt/recipes/default.rb
@@ -158,7 +158,7 @@ apt_repository "mediawiki" do
   uri "https://releases.wikimedia.org/debian"
   distribution "jessie-mediawiki"
   components ["main"]
-  key "90E9F83F22250DD7"
+  key "AF380A3036A03444" # Documented at https://www.mediawiki.org/wiki/Parsoid/Setup#Ubuntu_/_Debian
 end
 
 package "unattended-upgrades"


### PR DESCRIPTION
https://www.mediawiki.org/wiki/Parsoid/Setup#Ubuntu_/_Debian indicates that "AF380A3036A03444" is the current key. "90E9F83F22250DD7" did not work in testing.

Following suggestion in https://github.com/openstreetmap/chef/pull/259#discussion_r367044857