### PR TITLE
Change Wikibase site name to Data Items

### DIFF
--- a/cookbooks/wiki/templates/default/mw-ext-Wikibase.inc.php.erb
+++ b/cookbooks/wiki/templates/default/mw-ext-Wikibase.inc.php.erb
@@ -65,6 +65,7 @@ call_user_func( function() {
 // $wgWBClientSettings['showExternalRecentChanges'] = true;
 
 $wgWBClientSettings['namespaces'] = [ NS_MAIN ];
+$wgWBClientSettings['repoSiteName'] = "Data Items";
 
 // Avoid complaints that nobody seems to know the cause off...
 $wgWBClientSettings['entityUsagePerPageLimit'] = 500;


### PR DESCRIPTION
By default, it has the same name as the wiki instance which is misleading in case of "OpenStreetMap wiki", implements openstreetmap/operations#352

Documentation is located at https://phabricator.wikimedia.org/diffusion/EWBA/browse/master/docs/options.wiki;ad3f41c6e3692dc1e897ea6e70e08451d06a59b3$238. 