### PR TITLE
Configured Travis CI to run cookbooks via Test Kitchen

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -22,6 +22,7 @@ platforms:
     driver:
       name: dokken
       image: dokken/ubuntu-18.04
+      chef_version: 14
       provision: true
       # Docker and systemd need full capabilities granted in privileged mode
       privileged: true
@@ -33,10 +34,7 @@ platforms:
     provisioner:
       name: dokken
       product_name: chef
-      product_version: 14
       data_bags_path: test/data_bags
-      # Automatically accept Chef license when running headlessly
-      chef_license: accept
     transport:
       name: dokken
 

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,20 +12,30 @@ provisioner:
   data_bags_path: test/data_bags
 
 platforms:
+  # Ubuntu 18.04 is what’s used on the live OSM servers,
+  # according to https://hardware.openstreetmap.org/
   - name: ubuntu-18.04
   - name: ubuntu-18.04-ci
+    # Driver, transport, and provisioner using Docker and Chef Infra Client,
+    # necessary when used on virtual CI boxes that refuse to run Virtualbox or Vagrant.
+    # https://github.com/someara/kitchen-dokken
     driver:
       name: dokken
       image: dokken/ubuntu-18.04
       provision: true
+      # Docker and systemd need full capabilities granted in privileged mode
+      privileged: true
+      # Run systemd init to allow services like MySQL, etc. to function
       pid_one_command: /bin/systemd
       intermediate_instructions:
+        # Help APT find its required sources on first run
         - RUN /usr/bin/apt-get update -y
     provisioner:
       name: dokken
       product_name: chef
       product_version: 14
       data_bags_path: test/data_bags
+      # Automatically accept Chef license when running headlessly
       chef_license: accept
     transport:
       name: dokken

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -13,28 +13,49 @@ provisioner:
 
 platforms:
   - name: ubuntu-18.04
+  - name: ubuntu-18.04-ci
+    driver:
+      name: dokken
+      image: dokken/ubuntu-18.04
+      provision: true
+      pid_one_command: /bin/systemd
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update -y
+    provisioner:
+      name: dokken
+      product_name: chef
+      product_version: 14
+      data_bags_path: test/data_bags
+      chef_license: accept
+    transport:
+      name: dokken
 
 suites:
   - name: accounts
     run_list:
       - recipe[accounts::default]
+    excludes: ["ubuntu-18.04-ci"]
   - name: apache
     run_list:
       - recipe[apache::default]
+    excludes: ["ubuntu-18.04-ci"]
   - name: apt
     run_list:
       - recipe[apt::default]
   - name: bind
     run_list:
       - recipe[bind::default]
+    excludes: ["ubuntu-18.04-ci"]
   - name: blogs
     run_list:
       - recipe[accounts::default]
       - recipe[blogs::default]
+    excludes: ["ubuntu-18.04-ci"]
   - name: forum
     run_list:
       - recipe[accounts::default]
       - role[forum]
+    excludes: ["ubuntu-18.04-ci"]
   - name: letsencrypt
     run_list:
       - recipe[accounts::default]
@@ -44,26 +65,34 @@ suites:
       apt:
         sources:
           - openstreetmap
+    excludes: ["ubuntu-18.04-ci"]
   - name: munin
     run_list:
       - recipe[munin::default]
+    excludes: ["ubuntu-18.04-ci"]
   - name: munin-server
     run_list:
       - recipe[munin::server]
+    excludes: ["ubuntu-18.04-ci"]
   - name: mysql
     run_list:
       - recipe[mysql::default]
+    excludes: ["ubuntu-18.04-ci"]
   - name: networking
     run_list:
       - recipe[networking::default]
+    excludes: ["ubuntu-18.04-ci"]
   - name: otrs
     run_list:
       - recipe[accounts::default]
       - recipe[chef::default]
       - role[otrs]
+    excludes: ["ubuntu-18.04-ci"]
   - name: python
     run_list:
       - recipe[python::default]
+    excludes: ["ubuntu-18.04-ci"]
   - name: tools
     run_list:
       - recipe[tools::default]
+    excludes: ["ubuntu-18.04-ci"]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,20 @@
 sudo: false
 language: ruby
 cache: bundler
-script:
-  - bundle exec cookstyle -f fuubar
+services:
+  - docker
+before_script:
+  - gem install kitchen kitchen-dokken kitchen-vagrant
+  # Put just enough Vagrant in the PATH to satisfy Test-Kitchen. No actual
+  # Vagrant or Virtualbox is run on Travis; this fake shim that echoes a
+  # recent Vagrant version is only here to allow tests to proceed below.
+  - sudo bash -c 'echo "echo Vagrant 2.0.0-fake" > /usr/bin/vagrant'
+  - sudo chmod +x /usr/bin/vagrant
+jobs:
+  include:
+    - name: "Cookstyle"
+      script:
+      - bundle exec cookstyle -f fuubar
+    - name: "Kitchen Test Apt Cookbook"
+      script:
+      - kitchen test apt-ubuntu-1804-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache: bundler
 services:
   - docker
 before_script:
-  - gem install kitchen kitchen-dokken kitchen-vagrant
   # Put just enough Vagrant in the PATH to satisfy Test-Kitchen. No actual
   # Vagrant or Virtualbox is run on Travis; this fake shim that echoes a
   # recent Vagrant version is only here to allow tests to proceed below.
@@ -17,4 +16,4 @@ jobs:
       - bundle exec cookstyle -f fuubar
     - name: "Kitchen Test Apt Cookbook"
       script:
-      - kitchen test apt-ubuntu-1804-ci
+      - bundle exec kitchen test apt-ubuntu-1804-ci

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 gem "cookstyle"
+gem "kitchen-dokken"
 gem "kitchen-vagrant"
 gem "serverspec"
 gem "test-kitchen"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,9 +7,13 @@ GEM
     cookstyle (5.19.9)
       rubocop (= 0.75.1)
     diff-lcs (1.3)
+    docker-api (1.34.2)
+      excon (>= 0.47.0)
+      multi_json
     ed25519 (1.2.4)
     equatable (0.6.1)
     erubi (1.9.0)
+    excon (0.72.0)
     ffi (1.12.1)
     gssapi (1.3.0)
       ffi (>= 1.0.1)
@@ -17,6 +21,10 @@ GEM
       builder (>= 2.1.2)
     httpclient (2.8.3)
     jaro_winkler (1.5.4)
+    kitchen-dokken (2.8.1)
+      docker-api (~> 1.33)
+      lockfile (~> 2.1)
+      test-kitchen (>= 1.15, < 3)
     kitchen-vagrant (1.6.1)
       test-kitchen (>= 1.4, < 3)
     license-acceptance (1.0.13)
@@ -25,6 +33,7 @@ GEM
       tty-box (~> 0.3)
       tty-prompt (~> 0.18)
     little-plugger (1.1.4)
+    lockfile (2.1.3)
     logging (2.2.2)
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
@@ -149,6 +158,7 @@ PLATFORMS
 
 DEPENDENCIES
   cookstyle
+  kitchen-dokken
   kitchen-vagrant
   serverspec
   test-kitchen


### PR DESCRIPTION
In https://github.com/openstreetmap/chef/pull/259, we noted that observing Test Kitchen outputs required manual sharing of logs and some conversation about working Test Kitchen installations. This PR introduces the possibility of testing Chef cookbooks right in Travis CI, thanks to the use of [Docker under Kitchen-Dokken](https://github.com/someara/kitchen-dokken) which will successfully complete in a virtual environment such as Travis.

@jalessio and I have started with the small Apt cookbook suite as a proof of concept. Cookstyle and Kitchen tests now run in parallel with logs that can be shared and observed between editors in PRs to this repo. The [end-user display in Travis is pretty nice](https://travis-ci.org/openstreetmap/chef/builds/648120451):

<img width="809" alt="Screen Shot 2020-02-09 at 12 08 11 PM" src="https://user-images.githubusercontent.com/58730/74109054-f3452900-4b34-11ea-9e85-904e400f6112.png">

If accepted, future work would include adding each cookbook suite (Wiki, Website, etc.) in turn to the Travis config and ensuring that it passes tests. @gravitystorm has recommended that we break this work up over time and add remaining suites in followup PRs.

Notes:
- We’ve defined the Kitchen-Dokken platform somewhat redundantly to leave the current Vagrant default untouched. A future version of `.kitchen.yml` could be simplified a lot by abandoning Vagrant entirely, but for now this change should be completely backwards-compatible with existing Vagrant setups.
- Current Travis time limitation is 50 minutes per matrix build job. Optimistically this should cover all of our needs, but as we add Cookbook tests we may find that some of them run very slowly. We can try to increase our runtime ceiling with a paid Travis plan or use an alternate Test Kitchen driver such as EC2 if we encounter this problem in the future.
- Any Kitchen command with the current Vagrant driver present requires that `vagrant --version` returns a valid version string. Since we [can’t actually run Vagrant/Virtualbox on Travis](https://github.com/travis-ci/travis-ci/issues/6060#issuecomment-221395944), we cheat a little here by generating a one-line `/usr/bin/vagrant` to echo a fake version string. We could also `apt-get install vagrant` to be more correct, with some startup time cost.
