### PR TITLE
apt: Disable used apt-src per Ubuntu 18.04 default

### DIFF
--- a/cookbooks/apt/templates/default/sources.list.erb
+++ b/cookbooks/apt/templates/default/sources.list.erb
@@ -1,51 +1,49 @@
 # DO NOT EDIT - This file is being maintained by Chef
 
 deb http://<%= @archive_host %>/ubuntu/ <%= @codename %> main restricted
-deb-src http://<%= @archive_host %>/ubuntu/ <%= @codename %> main restricted
+# deb-src http://<%= @archive_host %>/ubuntu/ <%= @codename %> main restricted
 
 ## Major bug fix updates produced after the final release of the
 ## distribution.
 deb http://<%= @archive_host %>/ubuntu/ <%= @codename %>-updates main restricted
-deb-src http://<%= @archive_host %>/ubuntu/ <%= @codename %>-updates main restricted
+# deb-src http://<%= @archive_host %>/ubuntu/ <%= @codename %>-updates main restricted
 
 ## N.B. software from this repository is ENTIRELY UNSUPPORTED by the Ubuntu
 ## team. Also, please note that software in universe WILL NOT receive any
 ## review or updates from the Ubuntu security team.
 deb http://<%= @archive_host %>/ubuntu/ <%= @codename %> universe
-deb-src http://<%= @archive_host %>/ubuntu/ <%= @codename %> universe
+# deb-src http://<%= @archive_host %>/ubuntu/ <%= @codename %> universe
 deb http://<%= @archive_host %>/ubuntu/ <%= @codename %>-updates universe
-deb-src http://<%= @archive_host %>/ubuntu/ <%= @codename %>-updates universe
+# deb-src http://<%= @archive_host %>/ubuntu/ <%= @codename %>-updates universe
 
-## N.B. software from this repository is ENTIRELY UNSUPPORTED by the Ubuntu 
-## team, and may not be under a free licence. Please satisfy yourself as to 
-## your rights to use the software. Also, please note that software in 
+## N.B. software from this repository is ENTIRELY UNSUPPORTED by the Ubuntu
+## team, and may not be under a free licence. Please satisfy yourself as to
+## your rights to use the software. Also, please note that software in
 ## multiverse WILL NOT receive any review or updates from the Ubuntu
 ## security team.
 deb http://<%= @archive_host %>/ubuntu/ <%= @codename %> multiverse
-deb-src http://<%= @archive_host %>/ubuntu/ <%= @codename %> multiverse
+# deb-src http://<%= @archive_host %>/ubuntu/ <%= @codename %> multiverse
 deb http://<%= @archive_host %>/ubuntu/ <%= @codename %>-updates multiverse
-deb-src http://<%= @archive_host %>/ubuntu/ <%= @codename %>-updates multiverse
+# deb-src http://<%= @archive_host %>/ubuntu/ <%= @codename %>-updates multiverse
 
-## Uncomment the following two lines to add software from the 'backports'
-## repository.
 ## N.B. software from this repository may not have been tested as
 ## extensively as that contained in the main release, although it includes
 ## newer versions of some applications which may provide useful features.
 ## Also, please note that software in backports WILL NOT receive any review
 ## or updates from the Ubuntu security team.
 deb http://<%= @archive_host %>/ubuntu/ <%= @codename %>-backports main restricted universe multiverse
-deb-src http://<%= @archive_host %>/ubuntu/ <%= @codename %>-backports main restricted universe multiverse
+# deb-src http://<%= @archive_host %>/ubuntu/ <%= @codename %>-backports main restricted universe multiverse
 
 ## Uncomment the following two lines to add software from Canonical's
-## 'partner' repository. This software is not part of Ubuntu, but is
-## offered by Canonical and the respective vendors as a service to Ubuntu
-## users.
+## 'partner' repository.
+## This software is not part of Ubuntu, but is offered by Canonical and the
+## respective vendors as a service to Ubuntu users.
 # deb http://archive.canonical.com/ubuntu <%= @codename %> partner
 # deb-src http://archive.canonical.com/ubuntu <%= @codename %> partner
 
-deb http://security.ubuntu.com/ubuntu <%= @codename %>-security main restricted
-deb-src http://security.ubuntu.com/ubuntu <%= @codename %>-security main restricted
-deb http://security.ubuntu.com/ubuntu <%= @codename %>-security universe
-deb-src http://security.ubuntu.com/ubuntu <%= @codename %>-security universe
-deb http://security.ubuntu.com/ubuntu <%= @codename %>-security multiverse
-deb-src http://security.ubuntu.com/ubuntu <%= @codename %>-security multiverse
+deb http://security.ubuntu.com/ubuntu/ <%= @codename %>-security main restricted
+# deb-src http://security.ubuntu.com/ubuntu/ <%= @codename %>-security main restricted
+deb http://security.ubuntu.com/ubuntu/ <%= @codename %>-security universe
+# deb-src http://security.ubuntu.com/ubuntu/ <%= @codename %>-security universe
+deb http://security.ubuntu.com/ubuntu/ <%= @codename %>-security multiverse
+# deb-src http://security.ubuntu.com/ubuntu/ <%= @codename %>-security multiverse


### PR DESCRIPTION
Ubuntu 18.04 default install no longer enabled `apt-src` sources.

* Improves `apt-get update` speed
* Minor CI performance importment.