### PR TITLE
blogs: use bundle install deployment over global

### DIFF
--- a/cookbooks/blogs/recipes/default.rb
+++ b/cookbooks/blogs/recipes/default.rb
@@ -43,6 +43,7 @@ end
 git "/srv/blogs.openstreetmap.org" do
   action :sync
   repository "git://github.com/gravitystorm/blogs.osm.org.git"
+  depth 5
   user "blogs"
   group "blogs"
   notifies :run, "execute[/srv/blogs.openstreetmap.org/Gemfile]", :immediately
@@ -50,7 +51,7 @@ end
 
 execute "/srv/blogs.openstreetmap.org/Gemfile" do
   action :nothing
-  command "bundle install"
+  command "bundle install --deployment"
   cwd "/srv/blogs.openstreetmap.org"
   user "root"
   group "root"
@@ -59,7 +60,7 @@ end
 
 execute "/srv/blogs.openstreetmap.org" do
   action :nothing
-  command "bundle exec /usr/local/bin/pluto build -t osm -o build"
+  command "bundle exec pluto build -t osm -o build"
   cwd "/srv/blogs.openstreetmap.org"
   user "blogs"
   group "blogs"

--- a/cookbooks/blogs/recipes/default.rb
+++ b/cookbooks/blogs/recipes/default.rb
@@ -53,8 +53,8 @@ execute "/srv/blogs.openstreetmap.org/Gemfile" do
   action :nothing
   command "bundle install --deployment"
   cwd "/srv/blogs.openstreetmap.org"
-  user "root"
-  group "root"
+  user "blogs"
+  group "blogs"
   notifies :run, "execute[/srv/blogs.openstreetmap.org]", :immediately
 end
 

--- a/cookbooks/blogs/templates/default/cron.erb
+++ b/cookbooks/blogs/templates/default/cron.erb
@@ -2,4 +2,4 @@
 
 MAILTO=admins@openstreetmap.org
 
-*/30 * * * * blogs cd /srv/blogs.openstreetmap.org; bundle exec /usr/local/bin/pluto --quieter --config=/srv/blogs.openstreetmap.org build --dbpath=/srv/blogs.openstreetmap.org --template=osm --output=/srv/blogs.openstreetmap.org/build /srv/blogs.openstreetmap.org/planet.ini > /dev/null
+*/30 * * * * blogs cd /srv/blogs.openstreetmap.org; bundle exec pluto --quieter --config=/srv/blogs.openstreetmap.org build --dbpath=/srv/blogs.openstreetmap.org --template=osm --output=/srv/blogs.openstreetmap.org/build /srv/blogs.openstreetmap.org/planet.ini > /dev/null


### PR DESCRIPTION
Switch to using safe `bundle install --deployment` instead of
global install, which may conflict with other dependencies.