### PR TITLE
Remove schema_changes from irc bot

### DIFF
--- a/cookbooks/supybot/templates/default/git.conf.erb
+++ b/cookbooks/supybot/templates/default/git.conf.erb
@@ -79,14 +79,6 @@ commit link = https://github.com/gravitystorm/openstreetmap-carto/commit/%c
 channels = #osm-dev
 commit message = [%s|%b|%a] %m %l
 
-[osm-carto-schema]
-short name = osm-carto-schema
-url = git://github.com/gravitystorm/openstreetmap-carto.git
-branch = schema_changes
-commit link = https://github.com/gravitystorm/openstreetmap-carto/commit/%c
-channels = #osm-dev
-commit message = [%s|%b|%a] %m %l
-
 [osm-osm2pgsql]
 short name = osm-osm2pgsql
 url = git://github.com/openstreetmap/osm2pgsql.git


### PR DESCRIPTION
We merged gravitystorm/openstreetmap-carto#4032, so this branch is no longer needed.