### PR TITLE
git: tweak description for apache keepalive timeout

### DIFF
--- a/cookbooks/git/templates/default/apache.erb
+++ b/cookbooks/git/templates/default/apache.erb
@@ -47,8 +47,8 @@
         SetEnv GIT_PROJECT_ROOT /var/lib/git
         SetEnv GIT_HTTP_EXPORT_ALL
 
-        # Keepalive should be larger than git config uploadpack.keepalive to avoid potential race on slower links
-        KeepAliveTimeout 60
+        # KeepaliveTimeout longer than git config uploadpack.keepalive 5 second default
+        KeepAliveTimeout 20
 
         ScriptAlias /public /usr/lib/git-core/git-http-backend/public
         ScriptAlias /private /usr/lib/git-core/git-http-backend/private


### PR DESCRIPTION
Effectively a dummy commit to test Git Actions when git.openstreetmap.org has an MTU 1400.