### PR TITLE
Add new tile layers to MultiMaps extension

### DIFF
--- a/cookbooks/wiki/templates/default/mw-ext-MultiMaps.inc.php.erb
+++ b/cookbooks/wiki/templates/default/mw-ext-MultiMaps.inc.php.erb
@@ -14,4 +14,14 @@ $egMultiMaps_MapServices = [
     'attribution' => '&copy; <a href="https://osm.org/copyright">OpenStreetMap contributors</a>. Tiles courtesy of <a href="https://www.thunderforest.com/" target="_blank">Andy Allan</a>',
     'source' => 'https://tile.thunderforest.com/transport/{z}/{x}/{y}.png?apikey=<%= @thunderforest_key %>',
   ],
+  'cycle' => [
+    'service' => 'Leaflet',
+    'attribution' => '&copy; <a href="https://osm.org/copyright">OpenStreetMap contributors</a>. Tiles courtesy of <a href="https://www.thunderforest.com/" target="_blank">Andy Allan</a>',
+    'source' => 'https://tile.thunderforest.com/cycle/{z}/{x}/{y}.png?apikey=<%= @thunderforest_key %>',
+  ],
+  'french' => [
+    'service' => 'Leaflet',
+    'attribution' => 'donn&eacute;es &copy; <a href="https://www.osm.org/copyright">les contributeurs OpenStreetMap</a>, sous licence ODbL',
+    'source' => 'https://{s}.tile.openstreetmap.fr/osmfr/{z}/{x}/{y}.png',
+  ],
 ];


### PR DESCRIPTION
Then replacing Slippy Map with MultiMaps extension, I found that the first supports displaying Thunderforest's Cycle layer, while MultiMaps was not configured to do that. 
Additionally, I saw that a lot of French pages included links to the French style tile server, that is why I suggest to add this layer, too. This was previously discussed in cquest/osmfr-cartocss/issues/61 and osm-fr/infrastructure/issues/153. 