### PR TITLE
Block some heavy apps and default user-agents

### DIFF
--- a/cookbooks/tilecache/templates/default/nginx_tile.conf.erb
+++ b/cookbooks/tilecache/templates/default/nginx_tile.conf.erb
@@ -53,10 +53,14 @@ map $http_user_agent $denied_scraper {
   '~^R$'                 1; # Library Default
   '~^Java\/'             1; # Library Default
   '~^tiles$'             1; # Library Default
+  '~^okhttp\/'           1; # Library Default
   '~^runtastic'          1; # App
+  'Android'              1; # Default or fake
   'Mozilla/4.0'          1; # Fake
   'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)' 1;  # Fake
   '~^Where\ my\ children' 1; # App
+  'nossoonibusjp.android.crosswalk' 1; # App
+  'br.com.concisoti.potybus' 1; # App
 }
 
 map $http_referer $denied_referer {


### PR DESCRIPTION
`okhttp/` is a default user-agent and prohibited by the usage policy.

I can't identify what `Android` refers to. It doesn't match Android UAs I've seen, but it's either a faked UA or a generic UA I can't identify.

The two apps are from https://github.com/openstreetmap/operations/issues/371 and do not have attribution.

Not locally tested.