### PR TITLE
Block some taxi apps

### DIFF
--- a/cookbooks/tilecache/templates/default/nginx_tile.conf.erb
+++ b/cookbooks/tilecache/templates/default/nginx_tile.conf.erb
@@ -66,6 +66,9 @@ map $http_user_agent $denied_scraper {
   '~^Where\ my\ children' 1; # App
   'nossoonibusjp.android.crosswalk' 1; # App
   'br.com.concisoti.potybus' 1; # App
+  'com.soft373.taptaxi'  1;
+  'com.kradac.ktxcore'   1;
+  'ru.crowdsystems.topcontrol.knd' 1;
 }
 
 map $http_referer $denied_referer {


### PR DESCRIPTION
These apps were contacted about moving to a different tile service and did not reply.