### PR TITLE
Updated Git references to limit test failures

### DIFF
--- a/cookbooks/civicrm/attributes/default.rb
+++ b/cookbooks/civicrm/attributes/default.rb
@@ -22,7 +22,7 @@ default[:civicrm][:extensions][:civirules][:revision] = "2.11"
 
 default[:civicrm][:extensions][:mailchimp][:name] = "uk.co.vedaconsulting.mailchimp"
 default[:civicrm][:extensions][:mailchimp][:repository] = "https://github.com/veda-consulting/uk.co.vedaconsulting.mailchimp.git"
-default[:civicrm][:extensions][:mailchimp][:revision] = "25798ffe209650f12162a0cdc3c7ee9203d950f2"
+default[:civicrm][:extensions][:mailchimp][:revision] = "124083b29ab28246883bc83f207498a85f01ecde"
 
 default[:civicrm][:extensions][:username][:name] = "org.openstreetmap.username"
 default[:civicrm][:extensions][:username][:repository] = "https://github.com/grischard/org.openstreetmap.username.git"

--- a/cookbooks/db/recipes/base.rb
+++ b/cookbooks/db/recipes/base.rb
@@ -45,7 +45,7 @@ rails_port "www.openstreetmap.org" do
   directory "/srv/www.openstreetmap.org/rails"
   user "rails"
   group "rails"
-  repository "https://git.openstreetmap.org/public/rails.git"
+  repository "https://github.com/openstreetmap/openstreetmap-website.git"
   revision "live"
   database_host "localhost"
   database_name "openstreetmap"

--- a/cookbooks/stateofthemap/recipes/default.rb
+++ b/cookbooks/stateofthemap/recipes/default.rb
@@ -23,7 +23,7 @@ passwords = data_bag_item("stateofthemap", "passwords")
 
 git "/srv/stateofthemap.org" do
   action :sync
-  repository "https://git.openstreetmap.org/public/stateofthemap.git"
+  repository "https://github.com/openstreetmap/stateofthemap.git"
   revision "chooser"
   depth 1
   user "root"
@@ -60,7 +60,7 @@ end
 wordpress_theme "2007.stateofthemap.org-refreshwp-11" do
   theme "refreshwp-11"
   site "2007.stateofthemap.org"
-  repository "https://git.openstreetmap.org/public/stateofthemap.git"
+  repository "https://github.com/openstreetmap/stateofthemap.git"
   revision "theme-2007"
 end
 
@@ -87,7 +87,7 @@ end
 wordpress_theme "2008.stateofthemap.org-refreshwp-11" do
   theme "refreshwp-11"
   site "2008.stateofthemap.org"
-  repository "https://git.openstreetmap.org/public/stateofthemap.git"
+  repository "https://github.com/openstreetmap/stateofthemap.git"
   revision "theme-2008"
 end
 
@@ -104,7 +104,7 @@ end
 
 git "/srv/2009.stateofthemap.org" do
   action :sync
-  repository "https://git.openstreetmap.org/public/stateofthemap.git"
+  repository "https://github.com/openstreetmap/stateofthemap.git"
   revision "resources-2009"
   depth 1
   user "wordpress"
@@ -125,7 +125,7 @@ end
 wordpress_theme "2009.stateofthemap.org-aerodrome" do
   theme "aerodrome"
   site "2009.stateofthemap.org"
-  repository "https://git.openstreetmap.org/public/stateofthemap.git"
+  repository "https://github.com/openstreetmap/stateofthemap.git"
   revision "theme-2009"
 end
 
@@ -142,7 +142,7 @@ end
 
 git "/srv/2010.stateofthemap.org" do
   action :sync
-  repository "https://git.openstreetmap.org/public/stateofthemap.git"
+  repository "https://github.com/openstreetmap/stateofthemap.git"
   revision "resources-2010"
   depth 1
   user "wordpress"
@@ -161,7 +161,7 @@ end
 wordpress_theme "2010.stateofthemap.org-aerodrome" do
   theme "aerodrome"
   site "2010.stateofthemap.org"
-  repository "https://git.openstreetmap.org/public/stateofthemap.git"
+  repository "https://github.com/openstreetmap/stateofthemap.git"
   revision "theme-2010"
 end
 
@@ -185,7 +185,7 @@ end
 
 git "/srv/2011.stateofthemap.org" do
   action :sync
-  repository "https://git.openstreetmap.org/public/stateofthemap.git"
+  repository "https://github.com/openstreetmap/stateofthemap.git"
   revision "resources-2011"
   depth 1
   user "wordpress"
@@ -204,7 +204,7 @@ end
 wordpress_theme "2011.stateofthemap.org-aerodrome" do
   theme "aerodrome"
   site "2011.stateofthemap.org"
-  repository "https://git.openstreetmap.org/public/stateofthemap.git"
+  repository "https://github.com/openstreetmap/stateofthemap.git"
   revision "theme-2011"
 end
 
@@ -228,7 +228,7 @@ end
 
 git "/srv/2012.stateofthemap.org" do
   action :sync
-  repository "https://git.openstreetmap.org/public/stateofthemap.git"
+  repository "https://github.com/openstreetmap/stateofthemap.git"
   revision "resources-2012"
   depth 1
   user "wordpress"
@@ -247,7 +247,7 @@ end
 wordpress_theme "2012.stateofthemap.org-aerodrome" do
   theme "aerodrome"
   site "2012.stateofthemap.org"
-  repository "https://git.openstreetmap.org/public/stateofthemap.git"
+  repository "https://github.com/openstreetmap/stateofthemap.git"
   revision "theme-2012"
 end
 
@@ -271,7 +271,7 @@ end
 %w[2013].each do |year|
   git "/srv/#{year}.stateofthemap.org" do
     action :sync
-    repository "https://git.openstreetmap.org/public/stateofthemap.git"
+    repository "https://github.com/openstreetmap/stateofthemap.git"
     revision "site-#{year}"
     depth 1
     user "root"

--- a/cookbooks/supybot/templates/default/git.conf.erb
+++ b/cookbooks/supybot/templates/default/git.conf.erb
@@ -24,7 +24,7 @@ commit message = [%s|%b|%a] %m %l
 
 [osm-cgimap]
 short name = osm-cgimap
-url = https://git.openstreetmap.org/public/cgimap.git
+url = https://github.com/openstreetmap/openstreetmap/cgimap.git
 branch = master
 commit link = https://github.com/openstreetmap/cgimap/commit/%c
 channels = #osm-dev

--- a/cookbooks/supybot/templates/default/git.conf.erb
+++ b/cookbooks/supybot/templates/default/git.conf.erb
@@ -2,7 +2,7 @@
 
 [osm-website]
 short name = osm-website
-url = https://git.openstreetmap.org/public/rails.git
+url = https://github.com/openstreetmap/openstreetmap-website.git
 branch = master
 commit link = https://github.com/openstreetmap/openstreetmap-website/commit/%c
 channels = #osm-dev

--- a/cookbooks/supybot/templates/default/git.conf.erb
+++ b/cookbooks/supybot/templates/default/git.conf.erb
@@ -16,7 +16,7 @@ channels = #osm-dev
 
 [osm-chef-public]
 short name = osm-chef-public
-url = https://git.openstreetmap.org/public/chef.git
+url = https://github.com/openstreetmap/chef.git
 branch = master
 commit link = https://github.com/openstreetmap/chef/commit/%c
 channels = #osm-dev
@@ -32,7 +32,7 @@ commit message = [%s|%b|%a] %m %l
 
 [osm-dns]
 short name = osm-dns
-url = https://git.openstreetmap.org/public/dns.git
+url = https://github.com/openstreetmap/dns.git
 branch = master
 commit link = https://github.com/openstreetmap/dns/commit/%c
 channels = #osm-dev
@@ -40,7 +40,7 @@ commit message = [%s|%b|%a] %m %l
 
 [osm-potlatch2]
 short name = osm-potlatch2
-url = https://git.openstreetmap.org/public/potlatch2.git
+url = https://github.com/openstreetmap/potlatch2.git
 branch = master
 commit link = https://github.com/openstreetmap/potlatch2/commit/%c
 channels = #osm-dev

--- a/cookbooks/web/recipes/rails.rb
+++ b/cookbooks/web/recipes/rails.rb
@@ -74,7 +74,7 @@ rails_port "www.openstreetmap.org" do
   directory rails_directory
   user "rails"
   group "rails"
-  repository "https://git.openstreetmap.org/public/rails.git"
+  repository "https://github.com/openstreetmap/openstreetmap-website.git"
   revision "live"
   database_host node[:web][:database_host]
   database_name "openstreetmap"

--- a/cookbooks/web/resources/rails_port.rb
+++ b/cookbooks/web/resources/rails_port.rb
@@ -28,7 +28,7 @@ property :ruby, String, :default => "2.3"
 property :directory, String
 property :user, String
 property :group, String
-property :repository, String, :default => "https://git.openstreetmap.org/public/rails.git"
+property :repository, String, :default => "https://github.com/openstreetmap/openstreetmap-website.git"
 property :revision, String, :default => "live"
 property :run_migrations, [true, false], :default => false
 property :email_from, String, :default => "OpenStreetMap <support@openstreetmap.org>"

--- a/roles/dev.rb
+++ b/roles/dev.rb
@@ -98,7 +98,7 @@ default_attributes(
   :dev => {
     :rails => {
       :master => {
-        :repository => "https://git.openstreetmap.org/public/rails.git",
+        :repository => "https://github.com/openstreetmap/openstreetmap-website.git",
         :revision => "master",
         :cgimap_repository => "https://github.com/zerebubuth/openstreetmap-cgimap.git",
         :cgimap_revision => "master",
@@ -117,7 +117,7 @@ default_attributes(
         :revision => "locale"
       },
       :upload => {
-        :repository => "https://git.openstreetmap.org/public/rails.git",
+        :repository => "https://github.com/openstreetmap/openstreetmap-website.git",
         :revision => "master",
         :cgimap_repository => "https://github.com/zerebubuth/openstreetmap-cgimap.git",
         :cgimap_revision => "feature/bulk_upload"


### PR DESCRIPTION
`git.openstreetmap.org` often refuses connections when run under testing, leading to a lot of misleading failures. This set of changes re-points repos to `github.com` where I was able to find matching commits. More details in https://github.com/openstreetmap/chef/pull/259#issuecomment-600422643.