### PR TITLE
Add fake MS referer to block list

### DIFF
--- a/cookbooks/tilecache/templates/default/nginx_tile.conf.erb
+++ b/cookbooks/tilecache/templates/default/nginx_tile.conf.erb
@@ -93,6 +93,7 @@ map $http_referer $denied_referer {
   'https://www.google.com'         1; # Faked
   'https://google.com/'            1; # Faked
   'https://www.google.com/'        1; # Faked
+  'http://www.microsoft.com/'      1; # Faked
   '~^https?://pmap\.kuku\.lu/'           1; # Too much traffic
   '~^https?://[^.]*\.pmap\.kuku\.lu/'    1; # Too much traffic
   '~^https?://fastpokemap\.com/'         1; # Too much traffic


### PR DESCRIPTION
These are all coming with a referer of `Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.2; .NET CLR 1.0.3705;)` so we could block that instead