### PR TITLE
imagery: reprojected lu hillshade

### DIFF
--- a/cookbooks/imagery/recipes/lu_ngl_dtm.rb
+++ b/cookbooks/imagery/recipes/lu_ngl_dtm.rb
@@ -37,7 +37,7 @@ imagery_layer "ana_dtm_2017_hillshading" do
   site "ana-dtm-2017.openstreetmap.lu"
   default_layer true
   projection "EPSG:3857"
-  source "/data/imagery/lu/LUREF_NGL/lu_hillshade_2017-epsg-3857.tif"
+  source "/data/imagery/lu/LUREF_NGL/lu_hillshade_2017-epsg-3857-compress.tif"
   max_zoom 21
   title "DTM Hillshading"
   copyright "Copyright"

--- a/cookbooks/imagery/recipes/lu_ngl_dtm.rb
+++ b/cookbooks/imagery/recipes/lu_ngl_dtm.rb
@@ -36,8 +36,8 @@ end
 imagery_layer "ana_dtm_2017_hillshading" do
   site "ana-dtm-2017.openstreetmap.lu"
   default_layer true
-  projection "EPSG:2169"
-  source "/data/imagery/lu/LUREF_NGL/lu_hillshade_2017.tif"
+  projection "EPSG:3857"
+  source "/data/imagery/lu/LUREF_NGL/lu_hillshade_2017-epsg-3857.tif"
   max_zoom 21
   title "DTM Hillshading"
   copyright "Copyright"


### PR DESCRIPTION
Hi,
The hillshade tif was re-projected server-side, the offset visible [here](https://ana-dtm-2017.openstreetmap.lu/) should be solved.
@Firefishy, @grischard : gdaladdo with --config PHOTOMETRIC_OVERVIEW YCBCR failed with 

> ERROR 6: PHOTOMETRIC_OVERVIEW=YCBCR requires a source raster with only 3 bands (RGB)

, so I used the default value.

Edit: the commands I used are stored in the file `commands_executed.sh` on the server.