### PR TITLE
Hold off on Wialon block

### DIFF
--- a/cookbooks/tilecache/templates/default/nginx_tile.conf.erb
+++ b/cookbooks/tilecache/templates/default/nginx_tile.conf.erb
@@ -125,7 +125,7 @@ map $http_referer $denied_referer {
   '~^https?://geoportal360\.pl/'         1; # Too much traffic
   '~^https?://skelbiu\.lt/'              1; # Too much traffic
   '~^https?://[^.]*\.skelbiu\.lt/'       1; # Too much traffic
-  '~^https?://[^.]*\.wialon.com/'        1; # Too much traffic
+  # '~^https?://[^.]*\.wialon.com/'        1; # Too much traffic (hold per 2020-04-10 email)
 }
 
 map $http_referer $osm_referer {


### PR DESCRIPTION
Google was routing their emails to spam and they asked for more time.