### PR TITLE
RFC-formatted complainant address for easy copy/paste

### DIFF
--- a/cookbooks/dmca/files/default/html/index.php
+++ b/cookbooks/dmca/files/default/html/index.php
@@ -10,6 +10,8 @@ function process_data ($values) {
         $email_body = 'OpenStreetMap - Claim of Copyright Infringement form:'."\n\n";
         $email_body .= 'Automated Email - Form Posted.'."\n\n";
         $email_body .= print_r($values, true);
+        $reply_address = $values['name_first'].' '.$values['name_last'].' <'.$values['email'].'>';
+        $email_body .= 'Formatted address: '.$reply_address."\n\n";
         mail('dmca@osmfoundation.org','OSM Claim of Copyright Infringement', $email_body, 'From: OSMF Copyright Form <dmca@osmfoundation.org>', '-fdmca@osmfoundation.org');
 }
 ?>


### PR DESCRIPTION
Add fully formatted complainant address to dmca mail body for easy copy/pasting in responses
as discussed in the dwg. 
( $reply_address can potentially be used for a Reply-To header )