### PR TITLE
Allow md raid to use multiple threads for RAID5 and 6

### DIFF
--- a/cookbooks/devices/templates/default/udev.rules.erb
+++ b/cookbooks/devices/templates/default/udev.rules.erb
@@ -97,6 +97,6 @@ ACTION=="add", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", ENV{ID_MODEL}=="QEMU_HA
 ACTION=="add", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", ENV{ID_MODEL}=="QEMU_HARDDISK", ATTR{queue/scheduler}="noop"
 # Vendor is sometimes missing
 
-# Increase default MD raid5/raid6 strip cache
-ACTION=="add", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", ENV{MD_LEVEL}=="raid5", ATTR{md/stripe_cache_size}="8192"
-ACTION=="add", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", ENV{MD_LEVEL}=="raid6", ATTR{md/stripe_cache_size}="8192"
+# Increase default MD raid5/raid6 strip cache + group_thread_cnt
+ACTION=="add", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", ENV{MD_LEVEL}=="raid5", ATTR{md/stripe_cache_size}="8192", ATTR{md/group_thread_cnt}="4"
+ACTION=="add", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", ENV{MD_LEVEL}=="raid6", ATTR{md/stripe_cache_size}="8192", ATTR{md/group_thread_cnt}="4"


### PR DESCRIPTION
`group_thread_cnt` was added in kernel 4.9+ to allow mdraid to use multiple threads for some RAID5 and RAID6 operations.

With fast SSD and NVMe disk mdraid using a single thread is often a performance bottleneck.