### PR TITLE
kitchen: Upgrade ca-certificates prior to run

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -25,6 +25,7 @@ platforms:
       pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update -y
+        - RUN /usr/bin/apt-get install -y ca-certificates
 
 suites:
   - name: accounts


### PR DESCRIPTION
Upgrade `ca-certificates` to ensure current trusted root are installed.