### PR TITLE
Avoid warning running cookstyle due to Layout/HeredocIndentation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ Layout/ExtraSpacing:
   AllowForAlignment: true
 
 Layout/HeredocIndentation:
-  EnforcedStyle: squiggly
+  Enabled: true
 
 Naming/MethodParameterName:
   Enabled: false


### PR DESCRIPTION
When Ruby 2.3 support was dropped in RuboCop they changed the Layout/HeredocIndentation to only support squiggly so setting this just causes it to warn. Just enable it instead.

See https://github.com/rubocop-hq/rubocop/pull/8056

Signed-off-by: Tim Smith <tsmith@chef.io>