### PR TITLE
Bump planet-dump-ng version

### DIFF
--- a/cookbooks/planet/recipes/dump.rb
+++ b/cookbooks/planet/recipes/dump.rb
@@ -58,7 +58,7 @@ end
 git "/opt/planet-dump-ng" do
   action :sync
   repository "https://github.com/zerebubuth/planet-dump-ng.git"
-  revision "v1.1.6"
+  revision "v1.1.7"
   depth 1
   user "root"
   group "root"


### PR DESCRIPTION
New version has fixes for memory explosion and `pg_restore` argument changes.

* The behaviour of the standard C++ library has been fixed so that `std::vector<>::clear()` _does not_ deallocate memory. It seems that previous versions of the library _did_ deallocate, which is not standards conforming, but meant that a bug in `planet-dump-ng` went unnoticed and its memory usage exploded under the new version of the library.
* The `pg_restore` tool from PostgreSQL now requires either a database name or file output argument. Previously the default was to output to stdout, but now this is a hard requirement.

