### PR TITLE
Bump planet-dump-ng version to v1.1.8

### DIFF
--- a/cookbooks/planet/recipes/dump.rb
+++ b/cookbooks/planet/recipes/dump.rb
@@ -58,7 +58,7 @@ end
 git "/opt/planet-dump-ng" do
   action :sync
   repository "https://github.com/zerebubuth/planet-dump-ng.git"
-  revision "v1.1.7"
+  revision "v1.1.8"
   depth 1
   user "root"
   group "root"


### PR DESCRIPTION
This includes a concurrency limit for disk-write threads, which hopefully slows the process down to the point where it's not using infinite memory. I've left it set at the default of 16, but we can use the `--max-concurrency` argument to bring it down if it's still using too much memory.