### PR TITLE
Switch to un-blessed osmdata output

### DIFF
--- a/roles/tile.rb
+++ b/roles/tile.rb
@@ -76,11 +76,11 @@ default_attributes(
     },
     :data => {
       :simplified_land_polygons => {
-        :url => "https://osmdata.openstreetmap.de/download/simplified-land-polygons-complete-3857.zip",
+        :url => "https://osmdata.openstreetmap.de/new/simplified-land-polygons-complete-3857.zip",
         :refresh => true
       },
       :simplified_water_polygons => {
-        :url => "https://osmdata.openstreetmap.de/download/simplified-water-polygons-split-3857.zip",
+        :url => "https://osmdata.openstreetmap.de/new/simplified-water-polygons-split-3857.zip",
         :refresh => true
       },
       :admin_boundaries => {
@@ -88,11 +88,11 @@ default_attributes(
         :directory => "ne_110m_admin_0_boundary_lines_land"
       },
       :land_polygons => {
-        :url => "https://osmdata.openstreetmap.de/download/land-polygons-split-3857.zip",
+        :url => "https://osmdata.openstreetmap.de/new/land-polygons-split-3857.zip",
         :refresh => true
       },
       :water_polygons => {
-        :url => "https://osmdata.openstreetmap.de/download/water-polygons-split-3857.zip",
+        :url => "https://osmdata.openstreetmap.de/new/water-polygons-split-3857.zip",
         :refresh => true
       },
       :antarctica_icesheet_polygons => {


### PR DESCRIPTION
Due to a complicated and unfortunate mess, the blessed/marked good versions of the osmdata.openstreetmap.de output files have not been updated since Jan 9, 2020; and even though the original cause is (more or less) resolved, there have been enough changes in the past six months that the automatic script that blesses new versions still rejects them.

Happily, the un-blessed versions are still made available, just under slightly different URLs.

This is the minimal change needed to use those un-blessed files.

It is theoretically possible that joto, the maintainer of the osmdata box, may do a manual override (and I've requested that here: https://github.com/fossgis/osmdata/issues/12 ) -- but as an alternative, and in the meantime, this enables the coastline data to be updated.