### PR TITLE
Fix escaping in old-planet-file-cleanup cron rule.

### DIFF
--- a/cookbooks/planet/recipes/default.rb
+++ b/cookbooks/planet/recipes/default.rb
@@ -127,6 +127,6 @@ cron_d "old-planet-file-cleanup" do
   hour "3"
   day "1-7"
   user "www-data"
-  command "test $(date +\%u) -eq 1 && /usr/local/bin/old-planet-file-cleanup --debug"
+  command "test $(date +\\%u) -eq 1 && /usr/local/bin/old-planet-file-cleanup --debug"
   mailto "zerebubuth@gmail.com"
 end


### PR DESCRIPTION
The old planet file cleanup cron rule is intended to run on the first Monday of each month. Unfortunately, this is slightly difficult to write because cron triggers on [either the day-of-month or day-of-week](https://linux.die.net/man/5/crontab) fields, not both. The fix suggested in the man page is to use a `test $(date %u) -eq 1 &&` to filter the command execution. However, to make things more complicated, the percent sign is a special character for cron (it's an escaped newline) and regular uses of `%` must be backslash escaped.

Long story short, the `date \%u` in the template file needs an extra `\` if it is to be used in a quoted Ruby string. (Although it would be nice if the `cron_d` resource handled proper escaping to avoid cron's `%`-related footguns, apparently it passes the string through unmodified.)