### PR TITLE
civicrm: checkout full depth on extensions

### DIFF
--- a/cookbooks/civicrm/recipes/default.rb
+++ b/cookbooks/civicrm/recipes/default.rb
@@ -140,7 +140,6 @@ node[:civicrm][:extensions].each_value do |details|
     action :sync
     repository details[:repository]
     revision details[:revision]
-    depth 1
     user "wordpress"
     group "wordpress"
   end


### PR DESCRIPTION
This fixes the issue where git module is unable to checkout a hash for the civicrm.