### PR TITLE
remove SlippyMap extension from all wikis

### DIFF
--- a/cookbooks/mediawiki/resources/site.rb
+++ b/cookbooks/mediawiki/resources/site.rb
@@ -467,6 +467,7 @@ action :create do
     repository "https://github.com/Firefishy/SlippyMap.git"
     tag "live"
     update_site false
+    action :delete
   end
 
   mediawiki_extension "Mantle" do

--- a/cookbooks/mediawiki/templates/default/mw-ext-SlippyMap.inc.php.erb
+++ b/cookbooks/mediawiki/templates/default/mw-ext-SlippyMap.inc.php.erb
@@ -1,3 +1,0 @@
-<?php
-# DO NOT EDIT - This file is being maintained by Chef
-require_once($IP .'/extensions/SlippyMap/SlippyMap.php');


### PR DESCRIPTION
This is the last one of a series of PRs to replace MediaWiki's SlippyMap extension with MultiMaps extension. The plan and subsequent discussion can be found in #241 (see also Firefishy/SlippyMap/issues/2). 