### PR TITLE
Update cgimap.rb: set disable-api-write flag in case database is read-only. 

### DIFF
--- a/cookbooks/web/recipes/cgimap.rb
+++ b/cookbooks/web/recipes/cgimap.rb
@@ -37,7 +37,7 @@ end
 
 memcached_servers = node[:web][:memcached_servers] || []
 
-switches = database_readonly ? " --readonly" : ""
+switches = database_readonly ? " --disable-api-write" : ""
 
 systemd_service "cgimap" do
   description "OpenStreetMap API Server"


### PR DESCRIPTION
`--readonly` was a left-over from the times when CGImap still had a read-write and read-only backend. Now, that the read-write backend is gone, and at the same time, changeset uploads are supported, this pull requests sets the `--disable-api-write` flag instead, to block changeset uploads in case of a read only database.

  --disable-api-write       disable API write operations

