### PR TITLE
Bump planet-dump-ng version for tag order change.

### DIFF
--- a/cookbooks/planet/recipes/dump.rb
+++ b/cookbooks/planet/recipes/dump.rb
@@ -58,7 +58,7 @@ end
 git "/opt/planet-dump-ng" do
   action :sync
   repository "https://github.com/zerebubuth/planet-dump-ng.git"
-  revision "v1.1.8"
+  revision "v1.2.0"
   depth 1
   user "root"
   group "root"


### PR DESCRIPTION
Update to the latest version of planet-dump-ng, which changes the order of tags in the output file to match that used by other tools. Planet-dump-ng already has a _consistent_ ordering, but not a natural one. The new ordering sorts tag keys as UTF-8 encoded strings of bytes, so it's not a "proper" Unicode string sort but still more understandable than the previous method.

See [osmdbt#29](https://github.com/openstreetmap/osmdbt/issues/29) for previous discussion and more information.