### PR TITLE
auto-create *.torrent files (and RSS Feed for them)

### DIFF
--- a/cookbooks/planet/recipes/dump.rb
+++ b/cookbooks/planet/recipes/dump.rb
@@ -47,6 +47,7 @@ package %w[
   pbzip2
   php-cli
   php-curl
+  mktorrent
 ]
 
 directory "/opt/planet-dump-ng" do

--- a/cookbooks/planet/templates/default/old-planet-file-cleanup.erb
+++ b/cookbooks/planet/templates/default/old-planet-file-cleanup.erb
@@ -99,6 +99,7 @@ to_delete += deletions(
   /planet-([0-9]{6}).osm.pbf/,
   today,
   ["planet-%y%m%d.osm.pbf",
+   "planet-%y%m%d.osm.pbf.torrent",
    "planet-%y%m%d.osm.pbf.md5"])
 
 to_delete += deletions(
@@ -106,6 +107,7 @@ to_delete += deletions(
   /history-([0-9]{6}).osm.pbf/,
   today,
   ["history-%y%m%d.osm.pbf",
+   "history-%y%m%d.osm.pbf.torrent",
    "history-%y%m%d.osm.pbf.md5"])
 
 total_size = 0

--- a/cookbooks/planet/templates/default/planetdump.erb
+++ b/cookbooks/planet/templates/default/planetdump.erb
@@ -101,6 +101,56 @@ function mk_torrent {
      -o ${name}.torrent
 }
 
+# Function to create RSS/Atom feed for .torrent files
+function mk_rss {
+  type="$1"		# fixme "history" / "planet"
+  format="$2"		# fixme "pbf"
+  web_dir="$3"		# fixme "pbf/full-history" or "pbf"
+  disk_dir="$4"		# fixme "/store/planet/pbf/full-history"
+  old_pwd="$PWD"
+  rss_name="${type}-${format}-rss.xml"
+  rss_path="${old_pwd}/${rss_name}"
+  rss_baseurl="https://planet.openstreetmap.org"
+  rss_dirurl="${rss_baseurl}/${web_dir}"
+
+  cd "${disk_dir}"
+
+  # RSS header
+  printf '%s\n' \
+     '<?xml version="1.0" encoding="utf-8"?>' \
+     '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">' \
+     '<channel>' > "${rss_path}"
+  cat >> "${rss_path}" <<__EOF
+     <title>OpenStreetMap planet torrent RSS</title>
+     <link>${rss_baseurl}</link>
+     <atom:link href="${rss_dirurl}/${rss_name}" rel="self" type="application/rss+xml" />
+     <description>RSS feed for ${type}.osm.${format}.torrent</description>
+     <language>en-us</language>
+     <lastBuildDate>`date -R`</lastBuildDate>
+__EOF
+
+  # add RSS item for each torrent
+  for tf in `ls -1t *.torrent | grep -v latest | head -n 5`
+  do
+    cat >> "${rss_path}" <<__EOF
+     <item>
+        <title>$tf</title>
+        <guid>${rss_dirurl}/$tf</guid>
+        <pubDate>`date -R -r $tf`</pubDate>
+        <category>OpenStreetMap</category>
+        <link>${rss_dirurl}/$tf</link>
+        <enclosure url="${rss_dirurl}/$tf" length="`find -maxdepth 1 -name ${tf%.torrent} -printf "%s"`" type="application/x-bittorrent" />
+        <description>OSM Torrent $tf (torrent size: `find -maxdepth 1 -name $tf -printf "%s"`)</description>
+     </item>
+__EOF
+  done
+
+  # RSS footer
+  printf '</channel>\n</rss>\n' >> "${rss_path}"
+  cd "$old_pwd"
+  mv "${rss_path}" "${disk_dir}"
+}
+
 # Function to install a dump in place
 function install_dump {
   type="$1"
@@ -133,3 +183,7 @@ install_dump "history" "pbf" "<%= node[:planet][:dump][:pbf_history_directory] %
 
 # Remove pbf dumps older than 90 days
 find "<%= node[:planet][:dump][:pbf_directory] %>" "<%= node[:planet][:dump][:pbf_history_directory] %>" -maxdepth 1 -mindepth 1 -type f -mtime +90 \( -iname 'planet-*.pbf' -o -iname 'history-*.pbf' -o -iname 'planet-*.pbf.md5' -o -iname 'history-*.pbf.md5' -o -iname 'planet-*.pbf.torrent' -o -iname 'history-*.pbf.torrent' \) -delete
+
+# Create RSS feed of available *.torrent files to enable automatic seeders
+mk_rss "planet" "pbf" "pbf"  "<%= node[:planet][:dump][:pbf_directory] %>"
+mk_rss "history" "pbf" "pbf/full-history" "<%= node[:planet][:dump][:pbf_history_directory] %>"

--- a/cookbooks/planet/templates/default/planetdump.erb
+++ b/cookbooks/planet/templates/default/planetdump.erb
@@ -97,7 +97,7 @@ function mk_torrent {
      -w https://ftp.spline.de/pub/openstreetmap/${web_path} \
      -w https://osm.openarchive.site/${name} \
      -w https://downloads.opencagedata.com/planet/${name} \
-     -c "OpenStreetMap planet database dump, licensed under https://opendatacommons.org/licenses/odbl/ by OpenStreetMap contributors" \
+     -c "OpenStreetMap ${type} database dump, licensed under https://opendatacommons.org/licenses/odbl/ by OpenStreetMap contributors" \
      -o ${name}.torrent
 }
 

--- a/cookbooks/planet/templates/default/planetdump.erb
+++ b/cookbooks/planet/templates/default/planetdump.erb
@@ -79,7 +79,6 @@ function mk_torrent {
   type="$1"
   format="$2"
   web_dir="$3"
-  disk_dir="$4"
   name="${type}-${date}.osm.${format}"
   web_path="${web_dir}/${name}"
 
@@ -96,8 +95,6 @@ function mk_torrent {
      -w https://planet.openstreetmap.org/${web_path} \
      -c "OpenStreetMap planet database dump, licensed under https://opendatacommons.org/licenses/odbl/ by OpenStreetMap contributors" \
      -o ${name}.torrent
-
-  mv "${name}.torrent" "${disk_dir}"
 }
 
 # Function to install a dump in place
@@ -111,15 +108,16 @@ function install_dump {
 
   md5sum "${name}" > "${name}.md5"
   mkdir -p "${dir}/${year}"
+  test -f "${name}.torrent" && mv "${name}.torrent" "${dir}/${year}"
   mv "${name}" "${name}.md5" "${dir}/${year}"
   ln -sf "${year:-.}/${name}" "${dir}/${latest}"
   rm -f "${dir}/${latest}.md5"
   sed -e "s/${name}/${latest}/" "${dir}/${year}/${name}.md5" > "${dir}/${latest}.md5"
 }
 
-# Create torrent files and move them into place
-mk_torrent "planet" "pbf" "pbf" "<%= node[:planet][:dump][:pbf_directory] %>"
-mk_torrent "history" "pbf" "pbf/full-history" "<%= node[:planet][:dump][:pbf_history_directory] %>"
+# Create *.torrent files
+mk_torrent "planet" "pbf" "pbf"
+mk_torrent "history" "pbf" "pbf/full-history"
 
 # Move dumps into place
 install_dump "changesets" "bz2" "<%= node[:planet][:dump][:xml_directory] %>" "${year}"

--- a/cookbooks/planet/templates/default/planetdump.erb
+++ b/cookbooks/planet/templates/default/planetdump.erb
@@ -181,8 +181,12 @@ install_dump "history" "bz2" "<%= node[:planet][:dump][:xml_history_directory] %
 install_dump "planet" "pbf" "<%= node[:planet][:dump][:pbf_directory] %>"
 install_dump "history" "pbf" "<%= node[:planet][:dump][:pbf_history_directory] %>"
 
-# Remove pbf dumps older than 90 days
-find "<%= node[:planet][:dump][:pbf_directory] %>" "<%= node[:planet][:dump][:pbf_history_directory] %>" -maxdepth 1 -mindepth 1 -type f -mtime +90 \( -iname 'planet-*.pbf' -o -iname 'history-*.pbf' -o -iname 'planet-*.pbf.md5' -o -iname 'history-*.pbf.md5' -o -iname 'planet-*.pbf.torrent' -o -iname 'history-*.pbf.torrent' \) -delete
+# Remove pbf dumps (and associated metadata) older than 90 days
+find "<%= node[:planet][:dump][:pbf_directory] %>" "<%= node[:planet][:dump][:pbf_history_directory] %>" -maxdepth 1 -mindepth 1 -type f -mtime +90 \( \
+  -iname 'planet-*.pbf' -o -iname 'history-*.pbf' -o \
+  -iname 'planet-*.pbf.md5' -o -iname 'history-*.pbf.md5' -o \
+  -iname 'planet-*.pbf.torrent' -o -iname 'history-*.pbf.torrent' \
+  \) -delete
 
 # Create RSS feed of available *.torrent files to enable automatic seeders
 mk_rss "planet" "pbf" "pbf"  "<%= node[:planet][:dump][:pbf_directory] %>"

--- a/cookbooks/planet/templates/default/planetdump.erb
+++ b/cookbooks/planet/templates/default/planetdump.erb
@@ -89,10 +89,14 @@ function mk_torrent {
      -a udp://tracker-udp.gbitt.info:80/announce,http://tracker.gbitt.info/announce,https://tracker.gbitt.info/announce \
      -a http://retracker.local/announce \
      -w https://ftp5.gwdg.de/pub/misc/openstreetmap/planet.openstreetmap.org/${web_path} \
-     -w https://free.nchc.org.tw/osm.planet/${web_path} \
      -w https://ftpmirror.your.org/pub/openstreetmap/${web_path} \
-     -w https://planet.passportcontrol.net/${web_path} \
+     -w https://mirror.init7.net/openstreetmap/${web_path} \
      -w https://planet.openstreetmap.org/${web_path} \
+     -w https://free.nchc.org.tw/osm.planet/${web_path} \
+     -w https://ftp.fau.de/osm-planet/${web_path} \
+     -w https://ftp.spline.de/pub/openstreetmap/${web_path} \
+     -w https://osm.openarchive.site/${name} \
+     -w https://downloads.opencagedata.com/planet/${name} \
      -c "OpenStreetMap planet database dump, licensed under https://opendatacommons.org/licenses/odbl/ by OpenStreetMap contributors" \
      -o ${name}.torrent
 }

--- a/cookbooks/planet/templates/default/planetdump.erb
+++ b/cookbooks/planet/templates/default/planetdump.erb
@@ -103,10 +103,10 @@ function mk_torrent {
 
 # Function to create RSS/Atom feed for .torrent files
 function mk_rss {
-  type="$1"		# fixme "history" / "planet"
-  format="$2"		# fixme "pbf"
-  web_dir="$3"		# fixme "pbf/full-history" or "pbf"
-  disk_dir="$4"		# fixme "/store/planet/pbf/full-history"
+  type="$1"
+  format="$2"
+  web_dir="$3"
+  disk_dir="$4"
   old_pwd="$PWD"
   rss_name="${type}-${format}-rss.xml"
   rss_path="${old_pwd}/${rss_name}"
@@ -117,12 +117,12 @@ function mk_rss {
 
   # RSS header
   printf '%s\n' \
-     '<?xml version="1.0" encoding="utf-8"?>' \
-     '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">' \
+     '<?xml version="1.0" encoding="UTF-8"?>' \
+     '<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:atom="http://www.w3.org/2005/Atom">' \
      '<channel>' > "${rss_path}"
   cat >> "${rss_path}" <<__EOF
-     <title>OpenStreetMap planet torrent RSS</title>
-     <link>${rss_baseurl}</link>
+     <title>OpenStreetMap ${type} torrent RSS</title>
+     <link>${rss_dirurl}</link>
      <atom:link href="${rss_dirurl}/${rss_name}" rel="self" type="application/rss+xml" />
      <description>RSS feed for ${type}.osm.${format}.torrent</description>
      <language>en-us</language>
@@ -134,20 +134,20 @@ __EOF
   do
     cat >> "${rss_path}" <<__EOF
      <item>
-        <title>$tf</title>
-        <guid>${rss_dirurl}/$tf</guid>
-        <pubDate>`date -R -r $tf`</pubDate>
+        <title>${tf}</title>
+        <guid>${rss_dirurl}/${tf}</guid>
+        <pubDate>`date -R -r ${tf}`</pubDate>
         <category>OpenStreetMap</category>
-        <link>${rss_dirurl}/$tf</link>
-        <enclosure url="${rss_dirurl}/$tf" length="`find -maxdepth 1 -name ${tf%.torrent} -printf "%s"`" type="application/x-bittorrent" />
-        <description>OSM Torrent $tf (torrent size: `find -maxdepth 1 -name $tf -printf "%s"`)</description>
+        <link>${rss_dirurl}/${tf}</link>
+        <enclosure url="${rss_dirurl}/${tf}" length="`find -maxdepth 1 -name ${tf%.torrent} -printf "%s"`" type="application/x-bittorrent" />
+        <description>OSM Torrent ${tf} (torrent size: `find -maxdepth 1 -name ${tf} -printf "%s"`)</description>
      </item>
 __EOF
   done
 
   # RSS footer
   printf '</channel>\n</rss>\n' >> "${rss_path}"
-  cd "$old_pwd"
+  cd "${old_pwd}"
   mv "${rss_path}" "${disk_dir}"
 }
 

--- a/cookbooks/planet/templates/default/planetdump.erb
+++ b/cookbooks/planet/templates/default/planetdump.erb
@@ -74,6 +74,32 @@ time nice -n 19 /opt/planet-dump-ng/planet-dump-ng \
      -x "planet-${date}.osm.bz2" -X "history-${date}.osm.bz2" \
      -p "planet-${date}.osm.pbf" -P "history-${date}.osm.pbf"
 
+# Function to create bittorrent files
+function mk_torrent {
+  type="$1"
+  format="$2"
+  web_dir="$3"
+  disk_dir="$4"
+  name="${type}-${date}.osm.${format}"
+  web_path="${web_dir}/${name}"
+
+  mktorrent -l 22 ${name} \
+     -a udp://tracker.opentrackr.org:1337 \
+     -a udp://tracker.datacenterlight.ch:6969/announce,http://tracker.datacenterlight.ch:6969/announce \
+     -a udp://tracker.torrent.eu.org:451 \
+     -a udp://tracker-udp.gbitt.info:80/announce,http://tracker.gbitt.info/announce,https://tracker.gbitt.info/announce \
+     -a http://retracker.local/announce \
+     -w https://ftp5.gwdg.de/pub/misc/openstreetmap/planet.openstreetmap.org/${web_path} \
+     -w https://free.nchc.org.tw/osm.planet/${web_path} \
+     -w https://ftpmirror.your.org/pub/openstreetmap/${web_path} \
+     -w https://planet.passportcontrol.net/${web_path} \
+     -w https://planet.openstreetmap.org/${web_path} \
+     -c "OpenStreetMap planet database dump, licensed under https://opendatacommons.org/licenses/odbl/ by OpenStreetMap contributors" \
+     -o ${name}.torrent
+
+  mv "${name}.torrent" "${disk_dir}"
+}
+
 # Function to install a dump in place
 function install_dump {
   type="$1"
@@ -91,6 +117,10 @@ function install_dump {
   sed -e "s/${name}/${latest}/" "${dir}/${year}/${name}.md5" > "${dir}/${latest}.md5"
 }
 
+# Create torrent files and move them into place
+mk_torrent "planet" "pbf" "pbf" "<%= node[:planet][:dump][:pbf_directory] %>"
+mk_torrent "history" "pbf" "pbf/full-history" "<%= node[:planet][:dump][:pbf_history_directory] %>"
+
 # Move dumps into place
 install_dump "changesets" "bz2" "<%= node[:planet][:dump][:xml_directory] %>" "${year}"
 install_dump "discussions" "bz2" "<%= node[:planet][:dump][:xml_directory] %>" "${year}"
@@ -100,4 +130,4 @@ install_dump "planet" "pbf" "<%= node[:planet][:dump][:pbf_directory] %>"
 install_dump "history" "pbf" "<%= node[:planet][:dump][:pbf_history_directory] %>"
 
 # Remove pbf dumps older than 90 days
-find "<%= node[:planet][:dump][:pbf_directory] %>" "<%= node[:planet][:dump][:pbf_history_directory] %>" -maxdepth 1 -mindepth 1 -type f -mtime +90 \( -iname 'planet-*.pbf' -o -iname 'history-*.pbf' -o -iname 'planet-*.pbf.md5' -o -iname 'history-*.pbf.md5' \) -delete
+find "<%= node[:planet][:dump][:pbf_directory] %>" "<%= node[:planet][:dump][:pbf_history_directory] %>" -maxdepth 1 -mindepth 1 -type f -mtime +90 \( -iname 'planet-*.pbf' -o -iname 'history-*.pbf' -o -iname 'planet-*.pbf.md5' -o -iname 'history-*.pbf.md5' -o -iname 'planet-*.pbf.torrent' -o -iname 'history-*.pbf.torrent' \) -delete


### PR DESCRIPTION
This implements:
- Automatic creation of `.torrent` files (by using `mktorrent` program/package) for `pbf/planet-XXXXXX.osm.pbf` and `pbf/full-history/history-XXXXXX.osm.pbf` planet dump files (where `XXXXXX` is date like `201109`).

- RSS/Atom feed for aforementioned `.torrent` files, which allow dedicated torrent clients automatic seeding of new planet dumps. RSS will be available as `/pbf/planet-pbf-rss.xml` and `/pbf/full-history/history-pbf-rss.xml` URIs.

Some notes:
- while I obviously don't have whole OSM infrastructure to test, I did test `mk_rss` and `mk_torrent` bash functions locally, and they produce valid and working `.torrent` and `RSS` files.

- tracker selection: I removed dead trackers discussed in issue #451, and added those that do not have negative affiliations, are announced as public, and were fast and stable for some time. They provide a mix of UDP and HTTP endpoints, and also of IPv4/IPv6. There is also included `http://retracker.local`, sometimes used by endusers and ISPs to automagically provide fast tracker mirror (by simple DNS or `/etc/hosts` change)  

- webseed selection: I've added [all mirrors from wiki](https://wiki.openstreetmap.org/wiki/Planet.osm#Planet.osm_mirrors) which provide at least latest planet in `pbf/planet-XXXXXX.osm.pbf` format (mirrors providing only `planet-latest.osm.pbf` are ignored, as as it might be different file at the moment of torrenting), and support required HTTP range requests (tested). Some of those mirrors (Those listed below `-w https://planet.openstreetmap.org` in `mktorrent` webseed list) do not provide `history-XXXXXX.osm.pbf`, though - it won't affect correct operations, but obviously users won't get as much parallelization there as with `planet-XXXXXX.osm.pbf`. 

Let me know if further work is needed on this PR.

This pull request closes: https://github.com/openstreetmap/operations/issues/451