### PR TITLE
Ensure lockfile directory for changeset replication exists.

### DIFF
--- a/cookbooks/planet/recipes/replication.rb
+++ b/cookbooks/planet/recipes/replication.rb
@@ -174,6 +174,13 @@ directory "/store/planet/replication/changesets" do
   mode "755"
 end
 
+# lockfile directory for changeset replication (see template changesets.conf)
+directory "/run/lock/replication" do
+  owner "planet"
+  group "planet"
+  mode "755"
+end
+
 template "/etc/replication/changesets.conf" do
   source "changesets.conf.erb"
   user "root"


### PR DESCRIPTION
fcf52fb06a5ddb3e1cbb54164511aae2b135a80e altered the [lockfile directory for changeset replication](https://github.com/openstreetmap/chef/commit/fcf52fb06a5ddb3e1cbb54164511aae2b135a80e#diff-045e8c1decbd8a4f8465aa40ca33722f2c1c69fc629d057fd434be318f79a966R4), but that directory wasn't created in the recipe.