### PR TITLE
Only reserve one CPU for other tasks on render servers

### DIFF
--- a/cookbooks/tile/templates/default/render-lowzoom.erb
+++ b/cookbooks/tile/templates/default/render-lowzoom.erb
@@ -16,7 +16,7 @@ function update_<%= style %>
     --timestamp=${timestamp} \
     --tile-dir=/srv/tile.openstreetmap.org/tiles \
     --socket=/var/run/renderd/renderd.sock \
-    --num-threads=<%= node[:cpu][:total] - 2 %> \
+    --num-threads=<%= node[:cpu][:total] - 1 %> \
     --map="<%= style %>" \
     --max-load=70 \
     --min-zoom=0 --max-zoom=12

--- a/cookbooks/tile/templates/default/renderd.conf.erb
+++ b/cookbooks/tile/templates/default/renderd.conf.erb
@@ -2,7 +2,7 @@
 
 [renderd]
 socketname=/var/run/renderd/renderd.sock
-num_threads=<%= node[:cpu][:total] - 2 %>
+num_threads=<%= node[:cpu][:total] - 1 %>
 tile_dir=/srv/tile.openstreetmap.org/tiles
 stats_file=/var/run/renderd/renderd.stats
 

--- a/cookbooks/tile/templates/default/update-lowzoom.erb
+++ b/cookbooks/tile/templates/default/update-lowzoom.erb
@@ -12,7 +12,7 @@ function update_tiles
     --timestamp=$(stat -c %Y "/srv/tile.openstreetmap.org/styles/<%= @style %>/project.xml") \
     --tile-dir=/srv/tile.openstreetmap.org/tiles \
     --socket=/var/run/renderd/renderd.sock \
-    --num-threads=<%= node[:cpu][:total] - 2 %> \
+    --num-threads=<%= node[:cpu][:total] - 1 %> \
     --map="<%= @style %>" \
     --max-load=70 \
     --min-zoom=0 --max-zoom=12


### PR DESCRIPTION
I had a look at the CPU usage of our render servers. Below is Odin, which is typical

![image](https://user-images.githubusercontent.com/1190866/103319301-2eb74300-49e6-11eb-8611-3f1438dd6145.png)

They never reach 100% utilization, which is good, but I think we're leaving too much idle right now.

I graphed the idle CPU with the PromQL `sum by (instance) (rate(node_cpu_seconds_total{instance=~"albi|odin|ysera|rhaegal",mode="idle"}[$__rate_interval]))` and looked at a peak period where those four servers were capped in CPU and found they all had at least 2 threads idle.

pyrene and bowser did not hit a CPU cap.