### PR TITLE
Allow the translation of MediaWiki sidebar

### DIFF
--- a/cookbooks/mediawiki/templates/default/LocalSettings.php.erb
+++ b/cookbooks/mediawiki/templates/default/LocalSettings.php.erb
@@ -266,7 +266,8 @@ $wgAllowExternalImagesFrom = array( 'http://tile.openstreetmap.org/', 'https://t
 $wgNoFollowDomainExceptions = array( 'www.openstreetmap.org', 'josm.openstreetmap.de', 'taginfo.openstreetmap.org', 'blog.openstreetmap.org', 'wiki.osmfoundation.org' );
 
 # FIXME - move to specific
-$wgForceUIMsgAsContentMsg = array( 'mainpage-url', 'portal-url', 'mapfeatures-url', 'helppage' );
+# defines which links of the sidebar are translatable 
+$wgForceUIMsgAsContentMsg = array( 'mainpage-url', 'mapfeatures-url', 'contributors-url', 'helppage', 'blogs-url', 'shop-url', 'sitesupport-url' );
 
 # FIXME - move to specific
 $wgAllowUserJs = TRUE;


### PR DESCRIPTION
I try to explain the change without commenting to lengthy. 
**Current (faulty) behaviour:** When a user with a non-English interface clicks on a link in the sidebar a. k. a. menu of the wiki, they go to the English target page of the link.
**Expected correct behaviour:** The user clicks on the link and arrives at the page in the appropriate language
**What the change technically does:** It changes the MediaWiki interface configuration pages for which the system accepts translations. The [Sidebar configuration page](https://wiki.openstreetmap.org/wiki/MediaWiki:Sidebar) contains the menu entries. Each entry links to a page `____-url` which contains the link target. Link targets can be translated by wiki admins appending a slash and a language code to the page name, so [`mainpage-url/es`](https://wiki.openstreetmap.org/wiki/MediaWiki:Mainpage-url/es) defines the link target for Spanish users. The array contains the pages for which MediaWiki allows translations. Some link targets like the osm.org url do not need to be adapted to the interface language, that is why they are left out here. 
**Documentation:**
* [User request to define the array in the first place (2009)](https://wiki.openstreetmap.org/wiki/MediaWiki_talk:Sidebar#SideBar.27s_Links_Localisation)
* [MediaWiki configuration variable documentation](https://www.mediawiki.org/wiki/Manual:$wgForceUIMsgAsContentMsg)
* [Current request to fix Spanish menu entries](https://wiki.openstreetmap.org/wiki/MediaWiki_talk:Sidebar#Spanish_translation_request)