### PR TITLE
Update links on dev server homepage

### DIFF
--- a/cookbooks/dev/templates/default/dev.html.erb
+++ b/cookbooks/dev/templates/default/dev.html.erb
@@ -5,6 +5,6 @@ You've reached errol, the OpenStreetMap dev server. <br />
 <dt>If you are a user...</dt>
 <dd>You probably want <a href="https://www.openstreetmap.org/">OpenStreetMap</a> itself.</dd>
 <dt>If you are a developer...</dt>
-<dd>You might be interested in <a href="https://apis.dev.openstreetmap.org/">live instances</a> of various <a href="https://wiki.openstreetmap.org/index.php/The_Rails_Port#Installation_on_Debian">Rails Port</a> code branches in <a href="https://svn.openstreetmap.org/sites/rails_port_branches/">SVN</a> for testing clients against.</dd>
+<dd>You might be interested in <a href="https://apis.dev.openstreetmap.org/">live instances</a> of various <a href="https://github.com/openstreetmap/openstreetmap-website#readme">Rails Port</a> code branches for testing clients against.</dd>
 </body>
 </html>


### PR DESCRIPTION
Update some links on our little dev server homepage.
* The rails port install instructions are now in github.
* It's no longer serving up SVN branches (These days it's all github. That branches list is maintained here in chef https://github.com/openstreetmap/chef/blob/master/roles/dev.rb#L100 but I think that would be a bit of tangled thing to link to from this homepage)