### PR TITLE
Add new mirror as webseed to new torrents

### DIFF
--- a/cookbooks/planet/templates/default/planetdump.erb
+++ b/cookbooks/planet/templates/default/planetdump.erb
@@ -98,6 +98,7 @@ function mk_torrent {
      -w https://osm.openarchive.site/${name} \
      -w https://downloads.opencagedata.com/planet/${name} \
      -w https://planet.osm-hr.org/${web_path} \
+     -w https://planet.maps.mail.ru/${web_path} \
      -c "OpenStreetMap ${type} data export, licensed under https://opendatacommons.org/licenses/odbl/ by OpenStreetMap contributors" \
      -o ${name}.torrent
 }


### PR DESCRIPTION
Please add new mirror as web seed source to new torrents being created.
It is a Mail.ru Group based planet mirror, located at Russia, Moscow.
It is already described and advertised at https://wiki.openstreetmap.org/wiki/Planet.osm#Planet.osm_mirrors