### PR TITLE
Remove SimpleMap MediaWiki extension from all wikis

### DIFF
--- a/cookbooks/mediawiki/resources/site.rb
+++ b/cookbooks/mediawiki/resources/site.rb
@@ -471,6 +471,7 @@ action :create do
     repository "https://github.com/Firefishy/SimpleMap.git"
     tag "live"
     update_site false
+    action :delete
   end
 
   mediawiki_extension "SlippyMap" do

--- a/cookbooks/mediawiki/templates/default/mw-ext-SimpleMap.inc.php.erb
+++ b/cookbooks/mediawiki/templates/default/mw-ext-SimpleMap.inc.php.erb
@@ -1,3 +1,0 @@
-<?php
-# DO NOT EDIT - This file is being maintained by Chef
-require_once($IP .'/extensions/SimpleMap/SimpleMap.php');


### PR DESCRIPTION
SimpleMap extension (also known as [Simple Image MediaWiki extension](https://wiki.openstreetmap.org/wiki/Simple_image_MediaWiki_Extension)) requires an external [static map image](https://wiki.openstreetmap.org/wiki/Static_map_images)/tile stitching service to display rendered maps in the wikis. The two most recent providers cancelled their service, so the extension shows an empty image box since at least February 2020. [Multiple solutions](https://github.com/Firefishy/SimpleMap/issues/4#issuecomment-590058644) were suggested. However, nobody was interested in providing a tile stitching service and maintaining the extension. It remained broken for 15 months. 

The last suggestion was to replace this extension with "MultiMaps" extension installed on wiki.osm.org already. Following [consultations with the wiki](https://wiki.openstreetmap.org/w/index.php?title=Talk:Wiki&oldid=2155418#Replace_Simple_image_MediaWiki_extension_with_MultiMaps_extension) community, I made an automated edit. It replaced all occurrences of SimpleMap with MultiMaps. This PR removes the extension from all OSMF-hosted wiki instances. For reference, there was a similar situation and subsequent PR regarding the "SlippyMap" extension (#334). 

I assume that this extension was not used in any private OSMF-hosted wikis given it is broken for over a year and no issue was filed. SlippyMap extension was not used on the private wikis either. Removing the extension if in use would result in the original wiki markup showing up as raw text `<map lat=... />` instead of an `<img src=... />` i. e. it does not cause technical problems.  

Closes Firefishy/SimpleMap#4
Obsoletes fossgis/openstreetmap.de#36, Firefishy/SimpleMap#5