### PR TITLE
Run planet update for taginfo later

### DIFF
--- a/cookbooks/planet/recipes/current.rb
+++ b/cookbooks/planet/recipes/current.rb
@@ -53,7 +53,7 @@ remote_file "/var/lib/planet/planet.osh.pbf" do
 end
 
 cron_d "planet-update" do
-  minute "17"
+  minute "37"
   hour "1"
   user "root"
   command "/usr/local/bin/planet-update"


### PR DESCRIPTION
The planet update fails quite often for unknown reasons on the taginfo server. Maybe this is due to the process creating the hourly file running in the exact same moment or some other problem. This changes moves the cronjob a bit later to see whether it works better.