### PR TITLE
Increase log verbosity level of planet update

### DIFF
--- a/cookbooks/planet/templates/default/planet-update-file.erb
+++ b/cookbooks/planet/templates/default/planet-update-file.erb
@@ -12,12 +12,12 @@ PLANETCURR="${PLANETDIR}/planet.${SUFFIX}"
 PLANETNEW="${PLANETDIR}/planet-new.${SUFFIX}"
 PLANETTMP="${PLANETDIR}/planet-tmp.${SUFFIX}"
 
-pyosmium-up-to-date -v -o "$PLANETNEW" "$PLANETCURR"
+pyosmium-up-to-date -vvv -o "$PLANETNEW" "$PLANETCURR"
 retval=$?
 
 while [ $retval -eq 1 ]; do
     mv "$PLANETNEW" "$PLANETTMP"
-    pyosmium-up-to-date -v -o "$PLANETNEW" "$PLANETTMP"
+    pyosmium-up-to-date -vvv -o "$PLANETNEW" "$PLANETTMP"
     retval=$?
     rm "$PLANETTMP"
 done


### PR DESCRIPTION
Increase verbosity level of pyosmium-up-to-date in /usr/local/bin/planet-update to help finding out why it fails so often.