### PR TITLE
Append to planet update log instead of overwriting

### DIFF
--- a/cookbooks/planet/templates/default/planet-update.erb
+++ b/cookbooks/planet/templates/default/planet-update.erb
@@ -2,7 +2,7 @@
 
 # DO NOT EDIT - This file is being maintained by Chef
 
-exec > /var/log/planet-update.log 2>&1
+exec >> /var/log/planet-update.log 2>&1
 
 echo "Updating planet file..."
 


### PR DESCRIPTION
The planet update log of a run was writing over the previous log instead of appending. The log file is already rotated correctly, so it is not growing without bounds with this change.