### PR TITLE
Run tilelog earlier in the day

### DIFF
--- a/cookbooks/tilelog/recipes/default.rb
+++ b/cookbooks/tilelog/recipes/default.rb
@@ -50,8 +50,8 @@ template "/usr/local/bin/tilelog" do
 end
 
 cron_d "tilelog" do
-  minute "17"
-  hour "22"
+  minute "7"
+  hour "1"
   user "www-data"
   command "/usr/local/bin/tilelog"
   mailto "admins@openstreetmap.org"


### PR DESCRIPTION
The logs are pushed to S3 within minutes, so this can run much earlier in the day.

Depending on when this PR is merged, a manual run might be required.