### PR TITLE
Decrease tile rate limit to 30 TPS

### DIFF
--- a/cookbooks/tile/attributes/default.rb
+++ b/cookbooks/tile/attributes/default.rb
@@ -13,8 +13,8 @@ default[:tile][:replication][:url] = "https://planet.osm.org/replication/minute/
 default[:tile][:data] = {}
 default[:tile][:styles] = {}
 
-default[:tile][:ratelimit][:requests_per_second] = 20
-default[:tile][:ratelimit][:maximum_backlog] = 3600
+default[:tile][:ratelimit][:requests_per_second] = 15
+default[:tile][:ratelimit][:maximum_backlog] = 1800
 
 default[:postgresql][:versions] |= [node[:tile][:database][:cluster].split("/").first]
 

--- a/roles/pyrene.rb
+++ b/roles/pyrene.rb
@@ -68,8 +68,8 @@ default_attributes(
       }
     },
     :ratelimit => {
-      :requests_per_second => 40,
-      :maximum_backlog => 7200
+      :requests_per_second => 30,
+      :maximum_backlog => 3600
     }
   }
 )


### PR DESCRIPTION
This is 15 TPS per server, except for pyrene which needs 30.

Now that the rate limiting is working I reviewed IPs exceeding 20
TPS on an hour basis, looking at several days, and they were all
scrapers, or fakes which I would normally block if not for the effort.
I found no non-scraping proxies or NAT.