### PR TITLE
Increase usability of anti-spam features

### DIFF
--- a/cookbooks/mediawiki/templates/default/LocalSettings.php.erb
+++ b/cookbooks/mediawiki/templates/default/LocalSettings.php.erb
@@ -242,9 +242,6 @@ $wgEmailConfirmToEdit = true;
 # Extend autoblock period
 $wgAutoblockExpiry = 7776000; // 90 days
 
-# Spam filter regex
-$wgSpamRegex = '/\b(gmail|dell|asus|eps(o|0)n|br(o|0)ther|can(o|0)n|hp|k(o|0)dak|lexmark|mcafee|bitdefender|n(o|0)rt(o|0)n( 360)?|avira|kaspersky|avg|avast|micr(o|0)s(o|0)ft|(o|0)utl(o|0)(o|0)k|printer|netgear( r(o|0)uter)?|quickb(o|0)(o|0)ks( payr(o|0)ll)?)( antivirus)?( helpline| cust(o|0)mer|( technical| tech)| cust(o|0)mer service)? (supp(o|0)rt number|ph(o|0)ne number|supp(o|0)rt ph(o|0)ne number|care number|helpdesk number)\b/i';
-
 # Autopromote users to autoconfirmed
 $wgAutoConfirmAge = 345600; // 4 days
 $wgAutoConfirmCount = 10;

--- a/cookbooks/mediawiki/templates/default/mw-ext-SpamBlacklist.inc.php.erb
+++ b/cookbooks/mediawiki/templates/default/mw-ext-SpamBlacklist.inc.php.erb
@@ -5,3 +5,7 @@ wfLoadExtension( 'SpamBlacklist' );
 $wgSpamBlacklistFiles = array(
 	'https://meta.wikimedia.org/w/index.php?title=Spam_blacklist&action=raw&sb_ver=1'
 );
+# log hits, but allow only administrators to view them
+$wgLogSpamBlacklistHits = true;
+$wgGroupPermissions['user']['spamblacklistlog'] = false;
+$wgGroupPermissions['sysop']['spamblacklistlog'] = true;

--- a/cookbooks/mediawiki/templates/default/mw-ext-TitleBlacklist.inc.php.erb
+++ b/cookbooks/mediawiki/templates/default/mw-ext-TitleBlacklist.inc.php.erb
@@ -11,3 +11,7 @@ $wgTitleBlacklistSources = array(
     'src'  => 'https://meta.wikimedia.org/w/index.php?title=Title_blacklist&action=raw',
   ),
 );
+# log hits, but allow only administrators to view them
+$wgTitleBlacklistLogHits = true;
+$wgGroupPermissions['user']['titleblacklistlog'] = false;
+$wgGroupPermissions['sysop']['titleblacklistlog'] = true;


### PR DESCRIPTION
The first commit enables logging for two anti-spam wiki extensions. Currently, both [Spam blacklist log](https://wiki.openstreetmap.org/wiki/Special:Log?type=spamblacklist) and [Title blacklist log](https://wiki.openstreetmap.org/wiki/Special:Log?type=titleblacklist) are empty because logging is not enabled. I would like to use the logs to find spammers as well as wrong hits. By default, one log is visible to all signed-in users the other one is visible to administrators only. I explicitly set the viewing permissions to avoid changes with updates. 

The second commit removes the spam regex from the configuration files. I created a [similar abuse filter](https://wiki.openstreetmap.org/wiki/Special:AbuseFilter/11) instead. Abuse filters are editable by wiki administrators. The regex can be combined with other conditions such as the account age. 