### PR TITLE
remove account confirmation for private wikis

### DIFF
--- a/cookbooks/mediawiki/templates/default/LocalSettings.php.erb
+++ b/cookbooks/mediawiki/templates/default/LocalSettings.php.erb
@@ -185,16 +185,6 @@ $wgResourceLoaderMaxQueryLength = -1;
 # Only Allow Signed-in users to edit
 $wgGroupPermissions['*']['edit'] = false;
 
-# Only allow autoconfirmed for a few actions
-$wgGroupPermissions['user']['move'] = false;
-$wgGroupPermissions['user']['movefile'] = false;
-$wgGroupPermissions['user']['move-categorypages'] = false;
-$wgGroupPermissions['user']['upload'] = false;
-$wgGroupPermissions['autoconfirmed']['move'] = true;
-$wgGroupPermissions['autoconfirmed']['movefile'] = true;
-$wgGroupPermissions['autoconfirmed']['move-categorypages'] = true;
-$wgGroupPermissions['autoconfirmed']['upload'] = true;
-
 # Allow bureaucrat group access to oversight options
 $wgGroupPermissions['bureaucrat']['hideuser'] = true;
 $wgGroupPermissions['bureaucrat']['deletelogentry'] = true;
@@ -223,8 +213,8 @@ $wgGroupPermissions['sysop']['gadgets-definition-edit'] = true;
 $wgGroupPermissions['*']['createaccount'] = false;
 $wgGroupPermissions['user']['createaccount'] = true;
 <% end -%>
-<% if @mediawiki[:private_site] -%>
 
+<% if @mediawiki[:private_site] -%>
 # Disable reading by anonymous users
 $wgGroupPermissions['*']['read'] = false;
 
@@ -236,13 +226,6 @@ $wgGroupPermissions['*']['createaccount'] = false;
 
 # Restrict access to the upload directory
 $wgUploadPath = "$wgScriptPath/img_auth.php";
-<% end -%>
-
-<% if not(@mediawiki[:private_accounts]) and not(@mediawiki[:private_site]) -%>
-# user group "confirmed" with identical rights as "autoconfirmed", but assigned manually by sysops
-$wgGroupPermissions['confirmed'] = $wgGroupPermissions['autoconfirmed'];
-$wgAddGroups['sysop'][] = 'confirmed';
-$wgRemoveGroups['sysop'][] = 'confirmed';
 <% end -%>
 
 # Allow Subpages on Main Namespace
@@ -257,10 +240,6 @@ $wgEmailConfirmToEdit = true;
 
 # Extend autoblock period
 $wgAutoblockExpiry = 7776000; // 90 days
-
-# Autopromote users to autoconfirmed
-$wgAutoConfirmAge = 345600; // 4 days
-$wgAutoConfirmCount = 10;
 
 # Disable Hit Counter for Performance
 $wgDisableCounters = TRUE;
@@ -372,6 +351,41 @@ $wgSiteNotice = "<%= @mediawiki[:site_notice] %>";
 $wgReadOnly = "<%= @mediawiki[:site_readonly] %>";
 <% end -%>
 
+# load extensions
 <% Dir.glob("#{@directory}/LocalSettings.d/*.php") do |file| -%>
 <%= "require_once('#{file}');" %>
+<% end -%>
+
+<% if not(@mediawiki[:private_accounts]) and not(@mediawiki[:private_site]) -%>
+# require user confirmation for certain actions
+$wgGroupPermissions['user']['move'] = false;
+$wgGroupPermissions['user']['movefile'] = false;
+$wgGroupPermissions['user']['move-categorypages'] = false;
+$wgGroupPermissions['user']['upload'] = false;
+$wgGroupPermissions['autoconfirmed']['move'] = true;
+$wgGroupPermissions['autoconfirmed']['movefile'] = true;
+$wgGroupPermissions['autoconfirmed']['move-categorypages'] = true;
+$wgGroupPermissions['autoconfirmed']['upload'] = true;
+# Autopromote users to autoconfirmed
+$wgAutoConfirmAge = 345600; // 4 days
+$wgAutoConfirmCount = 10;
+
+# user group "confirmed" with identical rights as "autoconfirmed", but assigned manually by sysops
+$wgGroupPermissions['confirmed'] = $wgGroupPermissions['autoconfirmed'];
+$wgAddGroups['sysop'][] = 'confirmed';
+$wgRemoveGroups['sysop'][] = 'confirmed';
+<% end -%>
+
+<% if @mediawiki[:private_accounts] or @mediawiki[:private_site] -%>
+# disable automatic confirmation of users, grant all "autoconfirmed" rights to all users
+$wgAutoConfirmAge = 0;
+$wgAutoConfirmCount = 0;
+$wgGroupPermissions['user'] = array_merge( $wgGroupPermissions['user'], $wgGroupPermissions['autoconfirmed'] );
+
+unset( $wgGroupPermissions['autoconfirmed'] );
+unset( $wgRevokePermissions['autoconfirmed'] );
+unset( $wgAddGroups['autoconfirmed'] );
+unset( $wgRemoveGroups['autoconfirmed'] );
+unset( $wgGroupsAddToSelf['autoconfirmed'] );
+unset( $wgGroupsRemoveFromSelf['autoconfirmed'] );
 <% end -%>


### PR DESCRIPTION
### Explanation
The pull request removes the automatic account confirmation mechanism for "private account" wikis and "private site" wikis. It first sets the required number of edits and the required account age to 0 and then merges and deletes the "autoconfirmed" user group (identical as how the "interface admin" user group is deleted). The rest of the change moves code in the configuration file and adds comments. This is done to improve readability and to load extensions before manipulating those user rights. [In a separate file](https://github.com/openstreetmap/chef/blob/6c869d1b5625e8cbe1c091ed869c162bc9a6db59/cookbooks/mediawiki/templates/default/mw-ext-ConfirmEdit.inc.php.erb), the ConfirmEdit extension includes the configuration ```$wgGroupPermissions['autoconfirmed']['skipcaptcha'] = true;``` that is to be adapted to "all users skip the CAPTCHA" in case of private account and private site wikis or "autoconfirmed and manually confirmed users skip the CAPTCHA" in case of public wikis. This applies similarly to TimedMediaHandler extension. 

### Reasoning
Account confirmation is one measure against spam. When new accounts are created, one usually does not know if they are trustworthy. As a result, some hard-to-fix actions are disabled for them. This approach is reasonable for wikis that allow signing up for new accounts. In private site wikis, administrators are allowed to create new accounts only. In private account wikis, existing users are allowed to create new accounts only. In both cases, new users are trustworthy. As @tordanik explained, the present system of account confirmation even hinders onboarding of new board members because the user rights can not be granted manually. As [discussed previously](https://github.com/openstreetmap/operations/issues/488#issuecomment-749725192) account confirmation for non wiki.osm.org should be automatic. As a result, one ends up with this solution. 

### Request/Issue
The pull request fixes openstreetmap/operations#517. 