### PR TITLE
Add CategoryTree extension to wiki.osm.org

### DIFF
--- a/cookbooks/wiki/recipes/default.rb
+++ b/cookbooks/wiki/recipes/default.rb
@@ -60,6 +60,10 @@ mediawiki_site "wiki.openstreetmap.org" do
   # site_readonly "MAINTENANCE: WIKI READ-ONLY UNTIL Monday 16 May 2016 - 11:00am UTC/GMT."
 end
 
+mediawiki_extension "CategoryTree" do
+  site "wiki.openstreetmap.org"
+end
+
 mediawiki_extension "CodeEditor" do
   site "wiki.openstreetmap.org"
 end


### PR DESCRIPTION
A user [asked](https://wiki.openstreetmap.org/wiki/Talk:Wiki#Category_Tree_extension_missing) if this standard MediaWiki extension could be added to the wiki. I think it is useful especially when navigating in categories. 

Documentation: https://www.mediawiki.org/wiki/Extension:CategoryTree