### PR TITLE
Add PXE boot support using ipxe netboot.xyz

### DIFF
--- a/cookbooks/dhcpd/recipes/default.rb
+++ b/cookbooks/dhcpd/recipes/default.rb
@@ -19,7 +19,31 @@
 
 include_recipe "networking"
 
-package "isc-dhcp-server"
+package %w[
+  isc-dhcp-server
+  tftpd-hpa
+]
+
+service "tftpd-hpa" do
+  action [:enable, :start]
+  supports :status => true, :restart => true
+end
+
+remote_file "/srv/tftp/netboot.xyz.efi" do
+  action :create
+  source "https://boot.netboot.xyz/ipxe/netboot.xyz.efi"
+  owner "root"
+  group "root"
+  mode "644"
+end
+
+remote_file "/srv/tftp/netboot.xyz.kpxe" do
+  action :create
+  source "https://boot.netboot.xyz/ipxe/netboot.xyz.kpxe"
+  owner "root"
+  group "root"
+  mode "644"
+end
 
 domain = "#{node[:networking][:roles][:external][:zone]}.openstreetmap.org"
 

--- a/cookbooks/dhcpd/templates/default/dhcpd.conf.erb
+++ b/cookbooks/dhcpd/templates/default/dhcpd.conf.erb
@@ -1,5 +1,7 @@
 # DO NOT EDIT - This file is being maintained by Chef
 
+option architecture-type code 93 = unsigned integer 16;
+
 default-lease-time 600;
 max-lease-time 7200;
 <% node.interfaces(:role => :internal).each do |interface| -%>
@@ -12,6 +14,17 @@ subnet <%= interface[:network] %> netmask <%= interface[:netmask] %> {
   option domain-name "<%= @domain %>";
   option domain-name-servers <%= interface[:gateway] %>;
   option ntp-servers <%= node[:ntp][:servers].first %>;
+
+  class "pxeclients" {
+    match if substring (option vendor-class-identifier, 0, 9) = "PXEClient";
+    next-server <%= interface[:gateway] %>;
+
+    if option architecture-type = 00:07 {
+      filename "netboot.xyz.efi";
+    } else {
+      filename "netboot.xyz.kpxe";
+    }
+  }
 }
 <% end -%>
 


### PR DESCRIPTION
Add PXE support using ipxe with menus from netboot.xyz

This greatly simplifies my life installing ubuntu, burn-in tests or final machine wipe.