### PR TITLE
Enable BBR at Dublin with sufficient uplink and switch capacity

### DIFF
--- a/roles/equinix-dub.rb
+++ b/roles/equinix-dub.rb
@@ -2,6 +2,15 @@ name "equinix-dub"
 description "Role applied to all servers at Equinix Dublin"
 
 default_attributes(
+  :sysctl => {
+    :enable_bbr_10g => {
+      :comment => "Enable BBR. Equinix Dub has 10G uplink unlikely to buffer overrun",
+      :parameters => {
+        "net.ipv4.tcp_congestion_control" => "bbr",
+        "net.ipv4.tcp_notsent_lowat" => "16384"
+      }
+    }
+  },
   :networking => {
     :roles => {
       :internal => {


### PR DESCRIPTION
Equinix Dublin has a 10Gb uplink and significantly faster switches.

We had to disable BBR in Equinix Amsterdam due to the uplink going over capacity causing switch/router port buffer overrun and packet loss.

The same scenario is very unlikely to happen in Dublin with machines limited to 2x 1Gb each and uplink allowing 10Gb. 