### PR TITLE
Do not create temporary planet file when update was not complete

### DIFF
--- a/cookbooks/planet/templates/default/planet-update-file.erb
+++ b/cookbooks/planet/templates/default/planet-update-file.erb
@@ -10,16 +10,15 @@ PLANETDIR="/var/lib/planet"
 PLANETPREV="${PLANETDIR}/planet-previous.${SUFFIX}"
 PLANETCURR="${PLANETDIR}/planet.${SUFFIX}"
 PLANETNEW="${PLANETDIR}/planet-new.${SUFFIX}"
-PLANETTMP="${PLANETDIR}/planet-tmp.${SUFFIX}"
 
 pyosmium-up-to-date -vvv -o "$PLANETNEW" "$PLANETCURR"
 retval=$?
 
 while [ $retval -eq 1 ]; do
-    mv "$PLANETNEW" "$PLANETTMP"
-    pyosmium-up-to-date -vvv -o "$PLANETNEW" "$PLANETTMP"
+    mv "$PLANETCURR" "$PLANETPREV"
+    mv "$PLANETNEW" "$PLANETCURR"
+    pyosmium-up-to-date -vvv -o "$PLANETNEW" "$PLANETCURR"
     retval=$?
-    rm "$PLANETTMP"
 done
 
 if [ $retval -ne 0 ]; then


### PR DESCRIPTION
When the update of the planet file was not complete (when
pyosmium-up-to-date returns 1), the resulting planet is nevertheless
usable, so we can keep it instead of creating a temporary one. This way
we use less disk space because there is one fewer copy of the planet
around.