### PR TITLE
openssh: disable password authentication by default (except dev)

### DIFF
--- a/cookbooks/openssh/attributes/default.rb
+++ b/cookbooks/openssh/attributes/default.rb
@@ -1,1 +1,2 @@
 default[:openssh][:port] = 22
+default[:openssh][:password_authentication] = false

--- a/cookbooks/openssh/templates/default/sshd_config.conf.erb
+++ b/cookbooks/openssh/templates/default/sshd_config.conf.erb
@@ -1,3 +1,9 @@
 # DO NOT EDIT - This file is being maintained by Chef
 
 Port <%= node[:openssh][:port] %>
+
+<% if node[:openssh][:password_authentication] -%>
+PasswordAuthentication yes
+<% else -%>
+PasswordAuthentication no
+<% end -%>

--- a/roles/dev.rb
+++ b/roles/dev.rb
@@ -151,6 +151,9 @@ default_attributes(
         "kernel.shmmax" => "17179869184"
       }
     }
+  },
+  :openssh => {
+    :password_authentication => true
   }
 )
 


### PR DESCRIPTION
Disable openssh password authentication by default.

Closes: https://github.com/openstreetmap/operations/issues/603