### PR TITLE
Produce per-host referer logs for tiles

### DIFF
--- a/cookbooks/tilelog/recipes/default.rb
+++ b/cookbooks/tilelog/recipes/default.rb
@@ -31,7 +31,7 @@ end
 python_package "tilelog" do
   python_virtualenv tilelog_directory
   python_version "3"
-  version "0.4.0"
+  version "1.1.0"
 end
 
 directory tilelog_output_directory do

--- a/cookbooks/tilelog/templates/default/tilelog.erb
+++ b/cookbooks/tilelog/templates/default/tilelog.erb
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 if [ -z "$DATE" ]
 then
@@ -8,12 +9,18 @@ fi
 OUTDIR="<%= @output_dir %>"
 TMPDIR=$(mktemp -d -t tilelog.XXXXXXXXX)
 
-cd $TMPDIR
+cd "$TMPDIR"
 
 export AWS_ACCESS_KEY_ID="AKIASQUXHPE7JFCFMOUP"
 export AWS_SECRET_ACCESS_KEY="<%= @aws_key %>"
 export AWS_REGION="eu-west-1"
 
-nice -n 19 /opt/tilelog/bin/tilelog --date ${DATE} && mv tiles-${DATE}.txt.xz "${OUTDIR}"
+TILEFILE="tiles-${DATE}.txt.xz"
+HOSTFILE="hosts-${DATE}.csv"
 
-rm -rf $TMPDIR
+nice -n 19 /opt/tilelog/bin/tilelog --date "${DATE}" \
+  --tile "${TILEFILE}" --host "${HOSTFILE}"
+
+mv "${TILEFILE}" "${HOSTFILE}" "${OUTDIR}"
+
+rm -rf "$TMPDIR"


### PR DESCRIPTION
Ref: https://github.com/openstreetmap/tilelog/issues/2

This upgrades to tilelog 1.0.0 which allows producing multiple files, one of which is the existing log, the other is a log of top-usage websites.

The LWG has okayed showing aggregate referer information, and this requires >= 432000 requests/day to make the list.

An example of hosts decompressed is

```
"www.openstreetmap.org",1453.99,464.1
"localhost",310.3,26.29
"",151.82,28.89
"dro.routesmart.com",136.46,39.68
"www.openrailwaymap.org",123.65,18.54
"www.ad-production-stage.com",107.98,0.05
"r.onliner.by",96.64,1.78
"solagro.org",91.42,0.16
"tvil.ru",87.83,1.53
"eae.opekepe.gov.gr",84.88,12.98
"www.mondialrelay.fr",74.0,2.32
"www.lightningmaps.org",63.44,1.93
"nakarte.me",63.22,14.01
"qualp.com.br",55.1,0.74
"apps.sentinel-hub.com",52.77,11.25
"127.0.0.1",46.68,4.07
"www.gites-de-france.com",46.3,1.96
"www.anwb.nl",43.47,1.15
"dacota.lyft.net",42.46,10.52
"www.esri.com",41.13,6.63
```

