### PR TITLE
Upgrade to tilelog 1.2.0

### DIFF
--- a/cookbooks/tilelog/recipes/default.rb
+++ b/cookbooks/tilelog/recipes/default.rb
@@ -31,7 +31,7 @@ end
 python_package "tilelog" do
   python_virtualenv tilelog_directory
   python_version "3"
-  version "1.1.0"
+  version "1.2.0"
 end
 
 directory tilelog_output_directory do


### PR DESCRIPTION
This strips subdomains from the host list, merging into the privatesuffix (e.g. foo.example.com becomes example.com)