### PR TITLE
Update to tilelog 1.3.0

### DIFF
--- a/cookbooks/tilelog/recipes/default.rb
+++ b/cookbooks/tilelog/recipes/default.rb
@@ -31,7 +31,7 @@ end
 python_package "tilelog" do
   python_virtualenv tilelog_directory
   python_version "3"
-  version "1.2.0"
+  version "1.3.0"
 end
 
 directory tilelog_output_directory do


### PR DESCRIPTION
1.3.0 adds filtering to not count apps using webview as websites.