### PR TITLE
Increase prometheus retention time to 30d

### DIFF
--- a/cookbooks/prometheus/recipes/server.rb
+++ b/cookbooks/prometheus/recipes/server.rb
@@ -248,7 +248,7 @@ end
 systemd_service "prometheus-executable" do
   service "prometheus"
   dropin "executable"
-  exec_start "/opt/prometheus-server/prometheus/prometheus --config.file=/etc/prometheus/prometheus.yml --web.external-url=https://prometheus.openstreetmap.org/prometheus --storage.tsdb.path=/var/lib/prometheus/metrics2"
+  exec_start "/opt/prometheus-server/prometheus/prometheus --config.file=/etc/prometheus/prometheus.yml --web.external-url=https://prometheus.openstreetmap.org/prometheus --storage.tsdb.path=/var/lib/prometheus/metrics2 --storage.tsdb.retention.time=30d"
   notifies :restart, "service[prometheus]"
 end
 


### PR DESCRIPTION
Although long-term we want to move to using external storage (https://github.com/openstreetmap/operations/issues/484), this will give us a bit more time to look at metrics before they get flushed out of storage, which will help until we can get promscale working.

