### PR TITLE
supybot: remove old osm2pgsql branches

### DIFF
--- a/cookbooks/supybot/templates/default/git.conf.erb
+++ b/cookbooks/supybot/templates/default/git.conf.erb
@@ -86,30 +86,6 @@ commit link = https://github.com/openstreetmap/osm2pgsql/commit/%c
 channels = #osm-dev
 commit message = [%s|%b|%a] %m %l
 
-[osm-osm2pgsql-0.92.x]
-short name = osm-osm2pgsql-0.92.x
-url = https://github.com/openstreetmap/osm2pgsql.git
-branch = 0.92.x
-commit link = https://github.com/openstreetmap/osm2pgsql/commit/%c
-channels = #osm-dev
-commit message = [%s|%b|%a] %m %l
-
-[osm-osm2pgsql-0.90.x]
-short name = osm-osm2pgsql-0.90.x
-url = https://github.com/openstreetmap/osm2pgsql.git
-branch = 0.90.x
-commit link = https://github.com/openstreetmap/osm2pgsql/commit/%c
-channels = #osm-dev
-commit message = [%s|%b|%a] %m %l
-
-[osm-osm2pgsql-0.88.x]
-short name = osm-osm2pgsql-0.88.x
-url = https://github.com/openstreetmap/osm2pgsql.git
-branch = 0.88.x
-commit link = https://github.com/openstreetmap/osm2pgsql/commit/%c
-channels = #osm-dev
-commit message = [%s|%b|%a] %m %l
-
 [osm-mod_tile]
 short name = osm-mod_tile
 url = https://github.com/openstreetmap/mod_tile.git


### PR DESCRIPTION
These branches are no longer used, as versions this old aren't maintained.