### PR TITLE
Run low-zoom re-render weekly

### DIFF
--- a/cookbooks/tile/recipes/default.rb
+++ b/cookbooks/tile/recipes/default.rb
@@ -664,7 +664,7 @@ end
 
 systemd_timer "render-lowzoom" do
   description "Render low zoom tiles"
-  on_calendar "Sun *-*~07/1 01:00:00"
+  on_calendar "Fri *-*-* 23:00:00 UTC"
 end
 
 service "render-lowzoom.timer" do


### PR DESCRIPTION
Fixes #184
Fixes https://github.com/openstreetmap/operations/issues/582

Calendar expression testing:

```
$ systemd-analyze calendar "Fri *-*-* 23:00:00 UTC"
Normalized form: Fri *-*-* 23:00:00 UTC
    Next elapse: Fri 2022-07-15 16:00:00 PDT
       (in UTC): Fri 2022-07-15 23:00:00 UTC
       From now: 1 day 15h left
```

For the production tileservers, pyrene finishes in 6h; bowser, balerion, odin, and ysera finish in 3:15; and culebre and nidhogg finish in 1:00.

The older unused servers take longer, but those aren't a consideration.

At 2300 UTC on Friday all the servers are at a low load point. I considered scheduling towards the end of the weekend, but had a slight preference for the start.

I also considered local time zones when the servers have slightly lower load, but the load difference is not huge, and running all the re-renders at the same time will reduce the frequency of users seeing different tiles from different servers, which can confuse them.