### PR TITLE
hardware: Set OSM ilo defaults

### DIFF
--- a/cookbooks/hardware/recipes/default.rb
+++ b/cookbooks/hardware/recipes/default.rb
@@ -59,6 +59,19 @@ case manufacturer
 when "HP"
   package "hponcfg"
 
+  execute "update-ilo" do
+    action :nothing
+    command "/usr/sbin/hponcfg -f /etc/ilo-defaults.xml"
+  end
+
+  template "/etc/ilo-defaults.xml" do
+    source "ilo-defaults.xml.erb"
+    owner "root"
+    group "root"
+    mode "644"
+    notifies :run, "execute[update-ilo]"
+  end
+
   package "hp-health" do
     action :install
     notifies :restart, "service[hp-health]"

--- a/cookbooks/hardware/templates/default/ilo-defaults.xml.erb
+++ b/cookbooks/hardware/templates/default/ilo-defaults.xml.erb
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<RIBCL VERSION="2.0">
+  <LOGIN USER_LOGIN="admin" PASSWORD="password">
+    <SERVER_INFO mode="write">
+      <!-- Set Server Name -->
+      <SERVER_NAME VALUE="<%= node[:fqdn] %>"/>
+      <!-- 1 Operating system control mode -->
+      <!-- 2 HP Static Low Power mode -->
+      <!-- 3 HP Dynamic Power Savings mode -->
+      <!-- 4 HP Static High Performance mode -->
+      <SET_HOST_POWER_SAVER HOST_POWER_SAVER="3"/>
+      <!-- Set Auto Power ON -->
+      <!-- Set Auto Power after random delay -->
+      <!-- Both are required -->
+      <SERVER_AUTO_PWR VALUE="ON"/>
+      <SERVER_AUTO_PWR VALUE="RANDOM"/>
+      <!-- Unset max power cap -->
+      <SET_POWER_CAP POWER_CAP="0"/>
+    </SERVER_INFO>
+  </LOGIN>
+</RIBCL>


### PR DESCRIPTION
- Automatically power on servers after random interval
- HP Dynamic Power Savings mode (HP Default)
- Set server name in ilo
- Unset max power (Watt) cap.

Link: https://github.com/openstreetmap/operations/issues/686