### PR TITLE
Update to tilelog v1.4.0 and generate parquet files

### DIFF
--- a/cookbooks/tilelog/recipes/default.rb
+++ b/cookbooks/tilelog/recipes/default.rb
@@ -31,7 +31,7 @@ end
 python_package "tilelog" do
   python_virtualenv tilelog_directory
   python_version "3"
-  version "1.3.0"
+  version "1.4.0"
 end
 
 directory tilelog_output_directory do

--- a/cookbooks/tilelog/templates/default/tilelog.erb
+++ b/cookbooks/tilelog/templates/default/tilelog.erb
@@ -18,7 +18,7 @@ export AWS_REGION="eu-west-1"
 TILEFILE="tiles-${DATE}.txt.xz"
 HOSTFILE="hosts-${DATE}.csv"
 
-nice -n 19 /opt/tilelog/bin/tilelog --date "${DATE}" \
+nice -n 19 /opt/tilelog/bin/tilelog --date "${DATE}" --generate-success \
   --tile "${TILEFILE}" --host "${HOSTFILE}"
 
 mv "${TILEFILE}" "${HOSTFILE}" "${OUTDIR}"


### PR DESCRIPTION
- performance at generating the tile list file is substantially improved
- GZIP CSV logs are converted to parquet before files are made, resulting in less storage used and faster queries

As the queries now look at successful tile requests instead of all successful requests, usage numbers are not identical, but the changes are very minor.