### PR TITLE
Change Wikibase site name to Data Items

### DIFF
--- a/cookbooks/wiki/templates/default/mw-ext-Wikibase.inc.php.erb
+++ b/cookbooks/wiki/templates/default/mw-ext-Wikibase.inc.php.erb
@@ -65,6 +65,7 @@ call_user_func( function() {
 // $wgWBClientSettings['showExternalRecentChanges'] = true;
 
 $wgWBClientSettings['namespaces'] = [ NS_MAIN ];
+$wgWBClientSettings['repoSiteName'] = "Data Items";
 
 // Avoid complaints that nobody seems to know the cause off...
 $wgWBClientSettings['entityUsagePerPageLimit'] = 500;


### PR DESCRIPTION
By default, it has the same name as the wiki instance which is misleading in case of "OpenStreetMap wiki", implements openstreetmap/operations#352

Resurrects #261 which was not processed for over a year and finally closed by the author.

Fixes https://github.com/openstreetmap/operations/issues/352

While I am strongly disliking how data items turned out, I can confirm that for naming them data items is a clear consensus.