### PR TITLE
Update to osm-carto v5.6.0

### DIFF
--- a/cookbooks/tile/recipes/default.rb
+++ b/cookbooks/tile/recipes/default.rb
@@ -362,19 +362,15 @@ node[:tile][:styles].each do |name, details|
     group "tile"
   end
 
-  link "#{style_directory}/fonts" do
-    to "/srv/tile.openstreetmap.org/fonts"
-    owner "tile"
-    group "tile"
-  end
-
-  execute "#{style_directory}/fonts" do
-    action :nothing
-    command "scripts/get-fonts.sh"
-    cwd style_directory
-    user "tile"
-    group "tile"
-    subscribes :run, "git[#{style_directory}]"
+  if details[:fonts_script]
+    execute details[:fonts_script] do
+      action :nothing
+      command details[:fonts_script]
+      cwd style_directory
+      user "tile"
+      group "tile"
+      subscribes :run, "git[#{style_directory}]"
+    end
   end
 
   execute "#{style_directory}/project.mml" do

--- a/cookbooks/tile/recipes/default.rb
+++ b/cookbooks/tile/recipes/default.rb
@@ -165,30 +165,6 @@ python_package "pyotp" do
   python_version "3"
 end
 
-unifont = if node[:lsb][:release].to_f < 22.04
-            "ttf-unifont"
-          else
-            "fonts-unifont"
-          end
-
-package %W[
-  fonts-noto-cjk
-  fonts-noto-hinted
-  fonts-noto-unhinted
-  fonts-hanazono
-  #{unifont}
-]
-
-["NotoSansArabicUI-Regular.ttf", "NotoSansArabicUI-Bold.ttf"].each do |font|
-  remote_file "/usr/share/fonts/truetype/noto/#{font}" do
-    action :create_if_missing
-    source "https://github.com/googlei18n/noto-fonts/raw/master/hinted/#{font}"
-    owner "root"
-    group "root"
-    mode "644"
-  end
-end
-
 directory "/srv/tile.openstreetmap.org/cgi-bin" do
   owner "tile"
   group "tile"
@@ -384,6 +360,21 @@ node[:tile][:styles].each do |name, details|
     to "/srv/tile.openstreetmap.org/data"
     owner "tile"
     group "tile"
+  end
+
+  link "#{style_directory}/fonts" do
+    to "/srv/tile.openstreetmap.org/fonts"
+    owner "tile"
+    group "tile"
+  end
+
+  execute "#{style_directory}/fonts" do
+    action :nothing
+    command "scripts/get-fonts.sh"
+    cwd style_directory
+    user "tile"
+    group "tile"
+    subscribes :run, "git[#{style_directory}]"
   end
 
   execute "#{style_directory}/project.mml" do

--- a/roles/tile.rb
+++ b/roles/tile.rb
@@ -104,7 +104,7 @@ default_attributes(
     :styles => {
       :default => {
         :repository => "https://github.com/gravitystorm/openstreetmap-carto.git",
-        :revision => "v5.5.1",
+        :revision => "v5.6.0",
         :max_zoom => 19
       }
     }

--- a/roles/tile.rb
+++ b/roles/tile.rb
@@ -105,6 +105,7 @@ default_attributes(
       :default => {
         :repository => "https://github.com/gravitystorm/openstreetmap-carto.git",
         :revision => "v5.6.0",
+        :fonts_script => "/srv/tile.openstreetmap.org/styles/default/scripts/get-fonts.sh",
         :max_zoom => 19
       }
     }


### PR DESCRIPTION
Untested - not sure how to best test this. The style download should run before the CartoCSS is compiled.

I figure updating the fonts every new release is frequent enough, as they don't change *that* often.

Fixes #522