### PR TITLE
Produce app info files with tilelog

### DIFF
--- a/cookbooks/tilelog/templates/default/tilelog.erb
+++ b/cookbooks/tilelog/templates/default/tilelog.erb
@@ -17,10 +17,11 @@ export AWS_REGION="eu-west-1"
 
 TILEFILE="tiles-${DATE}.txt.xz"
 HOSTFILE="hosts-${DATE}.csv"
+APPFILE="apps-${DATE}.csv"
 
 nice -n 19 /opt/tilelog/bin/tilelog --date "${DATE}" --generate-success \
-  --tile "${TILEFILE}" --host "${HOSTFILE}"
+  --tile "${TILEFILE}" --host "${HOSTFILE}" --app "${APPFILE}"
 
-mv "${TILEFILE}" "${HOSTFILE}" "${OUTDIR}"
+mv "${TILEFILE}" "${HOSTFILE}" "${APPFILE}" "${OUTDIR}"
 
 rm -rf "$TMPDIR"


### PR DESCRIPTION
The files produce list apps, which are, approximately, non-browser users. The actual value is produced from user-agent, referer, and x-requested-with to produce something that meaningfully identifies the app.

App versions are dropped in order to get a more accurate total picture of usage coming from an app.

The data produced requires 432k requests before something appears in the output file, so it will not be a user-identifying user-agent, but something from a common browser or app.