### PR TITLE
Use UTC date when generating tile logs

### DIFF
--- a/cookbooks/tilelog/templates/default/tilelog.erb
+++ b/cookbooks/tilelog/templates/default/tilelog.erb
@@ -3,7 +3,7 @@ set -e
 
 if [ -z "$DATE" ]
 then
-  DATE=$(date -d "1 day ago" "+%Y-%m-%d")
+  DATE=$(date -u -d "1 day ago" "+%Y-%m-%d")
 fi
 
 OUTDIR="<%= @output_dir %>"


### PR DESCRIPTION
All the tile logging operates on UTC, so explicitly state so