### PR TITLE
Fix $wgExtraNamespaces[NS_PROPOSAL_TALK]

### DIFF
--- a/cookbooks/mediawiki/templates/default/LocalSettings.php.erb
+++ b/cookbooks/mediawiki/templates/default/LocalSettings.php.erb
@@ -361,7 +361,7 @@ $wgExtraNamespaces[NS_PROPOSAL] = 'Proposal';
 $wgNamespacesWithSubpages[NS_PROPOSAL] = TRUE;
 $wgContentNamespaces[] = NS_PROPOSAL;
 define('NS_PROPOSAL_TALK', 3001);
-$wgExtraNamespaces[NS_PROPOSAL_TALK] = 'Proposal talk';
+$wgExtraNamespaces[NS_PROPOSAL_TALK] = 'Proposal_talk';
 $wgNamespacesWithSubpages[NS_PROPOSAL_TALK] = TRUE;
 
 $wgNamespacesToBeSearchedDefault[NS_LANG_DE] = TRUE;


### PR DESCRIPTION
As per https://www.mediawiki.org/wiki/Manual:Using_custom_namespaces
the string values in $wgExtraNamespaces have to use underscores
instead of spaces ... otherwise MediaWiki wrongly recognizes
"Proposal_talk:Foo" to be in the main namespace.