### PR TITLE
Name php-fpm socket to work with apparmor-profiles

### DIFF
--- a/cookbooks/dev/templates/default/apache.phppgadmin.erb
+++ b/cookbooks/dev/templates/default/apache.phppgadmin.erb
@@ -16,9 +16,9 @@
 	# Remove Proxy request header to mitigate https://httpoxy.org/
 	RequestHeader unset Proxy early
 
-	ProxyPassMatch ^/(.*\.php(/.*)?)$ unix:/run/php/default.sock|fcgi://127.0.0.1
-	ProxyPassMatch ^/(.*\.phpx(/.*)?)$ unix:/run/php/default.sock|fcgi://127.0.0.1
-	ProxyPassMatch ^/(.*\.phpj(/.*)?)$ unix:/run/php/default.sock|fcgi://127.0.0.1
+	ProxyPassMatch ^/(.*\.php(/.*)?)$ unix:/run/php/php-default-fpm.sock|fcgi://127.0.0.1
+	ProxyPassMatch ^/(.*\.phpx(/.*)?)$ unix:/run/php/php-default-fpm.sock|fcgi://127.0.0.1
+	ProxyPassMatch ^/(.*\.phpj(/.*)?)$ unix:/run/php/php-default-fpm.sock|fcgi://127.0.0.1
 </VirtualHost>
 
 <VirtualHost *:80>

--- a/cookbooks/dev/templates/default/apache.user.erb
+++ b/cookbooks/dev/templates/default/apache.user.erb
@@ -30,7 +30,7 @@ WSGIDaemonProcess <%= @user %>.dev.openstreetmap.org user=<%= @user %> processes
 	RewriteRule ^/cgi-bin/(.*)$ /~<%= @user %>/cgi-bin/$1 [PT,L]
 
 	<FilesMatch ".+\.ph(p|ps|p3|tml)$">
-		SetHandler "proxy:unix:/run/php/<%= @user %>.sock|fcgi://127.0.0.1"
+		SetHandler "proxy:unix:/run/php/php-<%= @user %>-fpm.sock|fcgi://127.0.0.1"
 	</FilesMatch>
 </VirtualHost>
 

--- a/cookbooks/dmca/templates/default/apache.erb
+++ b/cookbooks/dmca/templates/default/apache.erb
@@ -53,6 +53,6 @@
   Require all granted
 
   <FilesMatch ".+\.ph(ar|p|tml)$">
-    SetHandler "proxy:unix:/run/php/<%= @name %>.sock|fcgi://127.0.0.1"
+    SetHandler "proxy:unix:/run/php/php-<%= @name %>-fpm.sock|fcgi://127.0.0.1"
   </FilesMatch>
 </Directory>

--- a/cookbooks/donate/templates/default/apache.erb
+++ b/cookbooks/donate/templates/default/apache.erb
@@ -42,7 +42,7 @@
     Require all granted
 
     <FilesMatch ".+\.ph(ar|p|tml)$">
-      SetHandler "proxy:unix:/run/php/donate.openstreetmap.org.sock|fcgi://127.0.0.1"
+      SetHandler "proxy:unix:/run/php/php-donate.openstreetmap.org-fpm.sock|fcgi://127.0.0.1"
     </FilesMatch>
   </Directory>
 

--- a/cookbooks/forum/templates/default/apache.erb
+++ b/cookbooks/forum/templates/default/apache.erb
@@ -40,7 +40,7 @@
 	DocumentRoot /srv/forum.openstreetmap.org/html
 
 	<FilesMatch ".+\.ph(ar|p|tml)$">
-		SetHandler "proxy:unix:/run/php/forum.openstreetmap.org.sock|fcgi://127.0.0.1"
+		SetHandler "proxy:unix:/run/php/php-forum.openstreetmap.org-fpm.sock|fcgi://127.0.0.1"
 	</FilesMatch>
 </VirtualHost>
 

--- a/cookbooks/matomo/templates/default/apache.erb
+++ b/cookbooks/matomo/templates/default/apache.erb
@@ -83,6 +83,6 @@
 	</FilesMatch>
 
         <FilesMatch ".+\.ph(ar|p|tml)$">
-                SetHandler "proxy:unix:/run/php/matomo.openstreetmap.org.sock|fcgi://127.0.0.1"
+                SetHandler "proxy:unix:/run/php/php-matomo.openstreetmap.org-fpm.sock|fcgi://127.0.0.1"
         </FilesMatch>
 </Directory>

--- a/cookbooks/mediawiki/templates/default/apache.erb
+++ b/cookbooks/mediawiki/templates/default/apache.erb
@@ -96,7 +96,7 @@
     Require all granted
 
     <FilesMatch ".+\.ph(ar|p|tml)$">
-      SetHandler "proxy:unix:/run/php/<%= @name %>.sock|fcgi://127.0.0.1"
+      SetHandler "proxy:unix:/run/php/php-<%= @name %>-fpm.sock|fcgi://127.0.0.1"
     </FilesMatch>
   </Directory>
 

--- a/cookbooks/nominatim/templates/default/nginx.erb
+++ b/cookbooks/nominatim/templates/default/nginx.erb
@@ -1,5 +1,5 @@
 upstream nominatim_service {
-  server unix:/run/php/nominatim.openstreetmap.org.sock;
+  server unix:/run/php/php-nominatim.openstreetmap.org-fpm.sock;
 }
 
 map $uri $nominatim_script_name {

--- a/cookbooks/php/resources/fpm.rb
+++ b/cookbooks/php/resources/fpm.rb
@@ -93,7 +93,7 @@ action_class do
     if new_resource.port
       "tcp://127.0.0.1:#{new_resource.port}/status"
     else
-      "unix:///run/php/#{new_resource.pool}.sock;/status"
+      "unix:///run/php/php-#{new_resource.pool}-fpm.sock;/status"
     end
   end
 end

--- a/cookbooks/php/templates/default/pool.conf.erb
+++ b/cookbooks/php/templates/default/pool.conf.erb
@@ -5,7 +5,7 @@
 listen = 127.0.0.1:<%= @port %>
 listen.backlog = 256
 <% else -%>
-listen = /run/php/<%= @pool %>.sock
+listen = /run/php/php-<%= @pool %>-fpm.sock
 listen.owner = www-data
 listen.group = www-data
 <% end -%>

--- a/cookbooks/wordpress/templates/default/apache.erb
+++ b/cookbooks/wordpress/templates/default/apache.erb
@@ -61,7 +61,7 @@
     Require all granted
 
     <FilesMatch ".+\.ph(ar|p|tml)$">
-      SetHandler "proxy:unix:/run/php/<%= @name %>.sock|fcgi://127.0.0.1"
+      SetHandler "proxy:unix:/run/php/php-<%= @name %>-fpm.sock|fcgi://127.0.0.1"
     </FilesMatch>
   </Directory>
 


### PR DESCRIPTION
`apparmor-profiles` package on errol (and elsewhere) provides a default php-fpm profile.
The socket is expected with name: `@{run}/php{,-fpm}/php*-fpm.sock`