### PR TITLE
Renice background services

### DIFF
--- a/cookbooks/chef/recipes/default.rb
+++ b/cookbooks/chef/recipes/default.rb
@@ -117,6 +117,7 @@ end
 systemd_service "chef-client" do
   description "Chef client"
   exec_start "/usr/bin/chef-client"
+  nice 10
 end
 
 systemd_timer "chef-client" do

--- a/cookbooks/dev/recipes/default.rb
+++ b/cookbooks/dev/recipes/default.rb
@@ -234,6 +234,7 @@ if node[:postgresql][:clusters][:"14/main"]
     working_directory "/srv/%i.apis.dev.openstreetmap.org/rails"
     exec_start "#{node[:ruby][:bundle]} exec rails jobs:work"
     restart "on-failure"
+    nice 10
     private_tmp true
     private_devices true
     protect_system "full"

--- a/cookbooks/gps-tile/recipes/default.rb
+++ b/cookbooks/gps-tile/recipes/default.rb
@@ -93,6 +93,7 @@ systemd_service "gps-update" do
   user "gpstile"
   working_directory "/srv/gps-tile.openstreetmap.org"
   exec_start "/srv/gps-tile.openstreetmap.org/updater/update"
+  nice 10
   private_tmp true
   private_devices true
   protect_system "full"

--- a/cookbooks/hardware/recipes/default.rb
+++ b/cookbooks/hardware/recipes/default.rb
@@ -325,6 +325,7 @@ if status_packages.include?("cciss-vol-status")
   systemd_service "cciss-vol-statusd" do
     description "Check cciss_vol_status values in the background"
     exec_start "/usr/local/bin/cciss-vol-statusd"
+    nice 10
     private_tmp true
     protect_system "full"
     protect_home true

--- a/cookbooks/planet/recipes/replication.rb
+++ b/cookbooks/planet/recipes/replication.rb
@@ -161,6 +161,7 @@ systemd_service "users-agreed" do
   description "Update list of users accepting CTs"
   user "planet"
   exec_start "/usr/local/bin/users-agreed"
+  nice 10
   private_tmp true
   private_devices true
   protect_system "full"
@@ -178,6 +179,7 @@ systemd_service "users-deleted" do
   description "Update list of deleted users"
   user "planet"
   exec_start "/usr/local/bin/users-deleted"
+  nice 10
   private_tmp true
   private_devices true
   protect_system "full"

--- a/cookbooks/rsyncd/recipes/default.rb
+++ b/cookbooks/rsyncd/recipes/default.rb
@@ -49,6 +49,7 @@ systemd_service "rsync-override" do
   service "rsync"
   dropin "override"
   exec_start "/usr/bin/rsync --daemon --no-detach --bwlimit=16384"
+  nice 10
   read_write_paths writable_paths.sort
   notifies :restart, "service[rsync]"
 end

--- a/cookbooks/tile/recipes/default.rb
+++ b/cookbooks/tile/recipes/default.rb
@@ -537,6 +537,7 @@ systemd_service "tile-ratelimit" do
   user "tile"
   group "adm"
   exec_start "/usr/local/bin/tile-ratelimit"
+  nice 10
   private_tmp true
   private_devices true
   private_network true
@@ -585,6 +586,7 @@ systemd_service "expire-tiles" do
   type "simple"
   user "_renderd"
   exec_start "/usr/local/bin/expire-tiles"
+  nice 10
   standard_output "null"
   private_tmp true
   private_devices true

--- a/cookbooks/tilelog/recipes/default.rb
+++ b/cookbooks/tilelog/recipes/default.rb
@@ -54,6 +54,7 @@ systemd_service "tilelog" do
   description "Tile log analysis"
   user "www-data"
   exec_start "/usr/local/bin/tilelog"
+  nice 10
   private_tmp true
   private_devices true
   protect_system "strict"

--- a/cookbooks/web/recipes/rails.rb
+++ b/cookbooks/web/recipes/rails.rb
@@ -157,6 +157,7 @@ systemd_service "rails-jobs@" do
   working_directory rails_directory
   exec_start "#{node[:ruby][:bundle]} exec rails jobs:work"
   restart "on-failure"
+  nice 10
   private_tmp true
   private_devices true
   protect_system "full"
@@ -193,6 +194,7 @@ systemd_service "api-statistics" do
   user "rails"
   group "adm"
   exec_start "/usr/local/bin/api-statistics"
+  nice 10
   private_tmp true
   private_devices true
   private_network true


### PR DESCRIPTION
Renice background service to allow full speed important services.
Reniced services will be ignored for ondemand CPU scaling saving power.

Signed-off-by: Grant Slater <git@firefishy.com>