### PR TITLE
Add initial support for other ubuntu ports (eg: arm64)

### DIFF
--- a/cookbooks/apt/recipes/default.rb
+++ b/cookbooks/apt/recipes/default.rb
@@ -39,18 +39,26 @@ apt_update "/etc/apt/sources.list" do
   action :nothing
 end
 
-archive_host = if node[:country]
-                 "#{node[:country]}.archive.ubuntu.com"
-               else
-                 "archive.ubuntu.com"
-               end
+if node[:kernel][:machine] == "x86_64"
+  archive_host = if node[:country]
+                   "#{node[:country]}.archive.ubuntu.com"
+                 else
+                   "archive.ubuntu.com"
+                 end
+  archive_security_host = "security.ubuntu.com"
+  archive_distro = "ubuntu"
+else
+  archive_host = "ports.ubuntu.com"
+  archive_security_host = archive_host
+  archive_distro = "ubuntu-ports"
+end
 
 template "/etc/apt/sources.list" do
   source "sources.list.erb"
   owner "root"
   group "root"
   mode "644"
-  variables :archive_host => archive_host, :codename => node[:lsb][:codename]
+  variables :archive_host => archive_host, :archive_security_host => archive_security_host, :archive_distro => archive_distro, :codename => node[:lsb][:codename]
   notifies :update, "apt_update[/etc/apt/sources.list]", :immediately
 end
 

--- a/cookbooks/apt/templates/default/sources.list.erb
+++ b/cookbooks/apt/templates/default/sources.list.erb
@@ -1,38 +1,38 @@
 # DO NOT EDIT - This file is being maintained by Chef
 
-deb http://<%= @archive_host %>/ubuntu/ <%= @codename %> main restricted
-# deb-src http://<%= @archive_host %>/ubuntu/ <%= @codename %> main restricted
+deb http://<%= @archive_host %>/<%= @archive_distro %>/ <%= @codename %> main restricted
+# deb-src http://<%= @archive_host %>/<%= @archive_distro %>/ <%= @codename %> main restricted
 
 ## Major bug fix updates produced after the final release of the
 ## distribution.
-deb http://<%= @archive_host %>/ubuntu/ <%= @codename %>-updates main restricted
-# deb-src http://<%= @archive_host %>/ubuntu/ <%= @codename %>-updates main restricted
+deb http://<%= @archive_host %>/<%= @archive_distro %>/ <%= @codename %>-updates main restricted
+# deb-src http://<%= @archive_host %>/<%= @archive_distro %>/ <%= @codename %>-updates main restricted
 
 ## N.B. software from this repository is ENTIRELY UNSUPPORTED by the Ubuntu
 ## team. Also, please note that software in universe WILL NOT receive any
 ## review or updates from the Ubuntu security team.
-deb http://<%= @archive_host %>/ubuntu/ <%= @codename %> universe
-# deb-src http://<%= @archive_host %>/ubuntu/ <%= @codename %> universe
-deb http://<%= @archive_host %>/ubuntu/ <%= @codename %>-updates universe
-# deb-src http://<%= @archive_host %>/ubuntu/ <%= @codename %>-updates universe
+deb http://<%= @archive_host %>/<%= @archive_distro %>/ <%= @codename %> universe
+# deb-src http://<%= @archive_host %>/<%= @archive_distro %>/ <%= @codename %> universe
+deb http://<%= @archive_host %>/<%= @archive_distro %>/ <%= @codename %>-updates universe
+# deb-src http://<%= @archive_host %>/<%= @archive_distro %>/ <%= @codename %>-updates universe
 
 ## N.B. software from this repository is ENTIRELY UNSUPPORTED by the Ubuntu
 ## team, and may not be under a free licence. Please satisfy yourself as to
 ## your rights to use the software. Also, please note that software in
 ## multiverse WILL NOT receive any review or updates from the Ubuntu
 ## security team.
-deb http://<%= @archive_host %>/ubuntu/ <%= @codename %> multiverse
-# deb-src http://<%= @archive_host %>/ubuntu/ <%= @codename %> multiverse
-deb http://<%= @archive_host %>/ubuntu/ <%= @codename %>-updates multiverse
-# deb-src http://<%= @archive_host %>/ubuntu/ <%= @codename %>-updates multiverse
+deb http://<%= @archive_host %>/<%= @archive_distro %>/ <%= @codename %> multiverse
+# deb-src http://<%= @archive_host %>/<%= @archive_distro %>/ <%= @codename %> multiverse
+deb http://<%= @archive_host %>/<%= @archive_distro %>/ <%= @codename %>-updates multiverse
+# deb-src http://<%= @archive_host %>/<%= @archive_distro %>/ <%= @codename %>-updates multiverse
 
 ## N.B. software from this repository may not have been tested as
 ## extensively as that contained in the main release, although it includes
 ## newer versions of some applications which may provide useful features.
 ## Also, please note that software in backports WILL NOT receive any review
 ## or updates from the Ubuntu security team.
-deb http://<%= @archive_host %>/ubuntu/ <%= @codename %>-backports main restricted universe multiverse
-# deb-src http://<%= @archive_host %>/ubuntu/ <%= @codename %>-backports main restricted universe multiverse
+deb http://<%= @archive_host %>/<%= @archive_distro %>/ <%= @codename %>-backports main restricted universe multiverse
+# deb-src http://<%= @archive_host %>/<%= @archive_distro %>/ <%= @codename %>-backports main restricted universe multiverse
 
 ## Uncomment the following two lines to add software from Canonical's
 ## 'partner' repository.
@@ -41,9 +41,9 @@ deb http://<%= @archive_host %>/ubuntu/ <%= @codename %>-backports main restrict
 # deb http://archive.canonical.com/ubuntu <%= @codename %> partner
 # deb-src http://archive.canonical.com/ubuntu <%= @codename %> partner
 
-deb http://security.ubuntu.com/ubuntu/ <%= @codename %>-security main restricted
-# deb-src http://security.ubuntu.com/ubuntu/ <%= @codename %>-security main restricted
-deb http://security.ubuntu.com/ubuntu/ <%= @codename %>-security universe
-# deb-src http://security.ubuntu.com/ubuntu/ <%= @codename %>-security universe
-deb http://security.ubuntu.com/ubuntu/ <%= @codename %>-security multiverse
-# deb-src http://security.ubuntu.com/ubuntu/ <%= @codename %>-security multiverse
+deb http://<%= @archive_security_host %>/<%= @archive_distro %>/ <%= @codename %>-security main restricted
+# deb-src http://<%= @archive_security_host %>/<%= @archive_distro %>/ <%= @codename %>-security main restricted
+deb http://<%= @archive_security_host %>/<%= @archive_distro %>/ <%= @codename %>-security universe
+# deb-src http://<%= @archive_security_host %>/<%= @archive_distro %>/ <%= @codename %>-security universe
+deb http://<%= @archive_security_host %>/<%= @archive_distro %>/ <%= @codename %>-security multiverse
+# deb-src http://<%= @archive_security_host %>/<%= @archive_distro %>/ <%= @codename %>-security multiverse


### PR DESCRIPTION
This is used for example when running test kitchen on recent Apple devices.