### PR TITLE
Add pandoc package to dev server

### DIFF
--- a/cookbooks/dev/recipes/default.rb
+++ b/cookbooks/dev/recipes/default.rb
@@ -125,6 +125,7 @@ package %w[
   whois
   redis
   r-base
+  pandoc
 ]
 
 nodejs_package "svgo"


### PR DESCRIPTION
Could we please install the `pandoc` package on the dev server? Needed for [FHODOT statistics](https://gregrs.dev.openstreetmap.org/fhodot/summary.html). Thanks.