### PR TITLE
Upgrade to tilelog 1.4.1

### DIFF
--- a/cookbooks/tilelog/recipes/default.rb
+++ b/cookbooks/tilelog/recipes/default.rb
@@ -31,7 +31,7 @@ end
 python_package "tilelog" do
   python_virtualenv tilelog_directory
   python_version "3"
-  version "1.4.0"
+  version "1.4.1"
 end
 
 directory tilelog_output_directory do


### PR DESCRIPTION
1.4.1 detects more UAs for combining versions.