### PR TITLE
Specify mapnik version for CartoCSS

### DIFF
--- a/cookbooks/tile/recipes/default.rb
+++ b/cookbooks/tile/recipes/default.rb
@@ -377,7 +377,7 @@ node[:tile][:styles].each do |name, details|
 
   execute "#{style_directory}/project.mml" do
     action :nothing
-    command "carto -a 3.0.0 project.mml > project.xml"
+    command "carto -a 3.0.22 project.mml > project.xml"
     cwd style_directory
     user "tile"
     group "tile"


### PR DESCRIPTION
OpenStreetMap Carto requires, and we use, at least 3.0.22.