### PR TITLE
Update to OpenStreetMap Carto v5.6.2

### DIFF
--- a/roles/tile.rb
+++ b/roles/tile.rb
@@ -105,7 +105,7 @@ default_attributes(
     :styles => {
       :default => {
         :repository => "https://github.com/gravitystorm/openstreetmap-carto.git",
-        :revision => "v5.6.1",
+        :revision => "v5.6.2",
         :fonts_script => "/srv/tile.openstreetmap.org/styles/default/scripts/get-fonts.sh",
         :max_zoom => 19
       }


### PR DESCRIPTION
Fixes a typo causing issues with fonts.