### PR TITLE
letencrypt: Use default certificate chain

### DIFF
--- a/cookbooks/letsencrypt/files/default/bin/renew
+++ b/cookbooks/letsencrypt/files/default/bin/renew
@@ -4,7 +4,6 @@ cd /srv/acme.openstreetmap.org
 
 /usr/bin/certbot renew \
     --quiet \
-    --preferred-chain "DST Root CA X3" \
     --config-dir /srv/acme.openstreetmap.org/config \
     --work-dir /srv/acme.openstreetmap.org/work \
     --logs-dir /srv/acme.openstreetmap.org/logs \

--- a/cookbooks/letsencrypt/templates/default/request.erb
+++ b/cookbooks/letsencrypt/templates/default/request.erb
@@ -4,7 +4,6 @@
 
 /usr/bin/certbot certonly \
     --non-interactive \
-    --preferred-chain "DST Root CA X3" \
     --config-dir /srv/acme.openstreetmap.org/config \
     --work-dir /srv/acme.openstreetmap.org/work \
     --logs-dir /srv/acme.openstreetmap.org/logs \


### PR DESCRIPTION
Use the letsencrypt default certificate chain as recommended by API.

Previously chain of trust needed to be overridden for extended compatibility, I believe this is no longer required.

[Letsencrypt have a complicated chain of trust](https://letsencrypt.org/certificates/), it likely best to use their default recommended chain.