### PR TITLE
Attempt to fix missing images in Kartographer wiki extension

### DIFF
--- a/cookbooks/wiki/templates/default/mw-ext-Kartographer.inc.php.erb
+++ b/cookbooks/wiki/templates/default/mw-ext-Kartographer.inc.php.erb
@@ -3,6 +3,7 @@
 
 wfLoadExtension( 'Kartographer' );
 $wgKartographerMapServer = 'https://tile.openstreetmap.org';
+$wgKartographerSrcsetScales = [];
 $wgKartographerDfltStyle = '';
 $wgKartographerStyles = [];
-
+$wgKartographerSimpleStyleMarkers = false;


### PR DESCRIPTION
Following openstreetmap/chef#552, there are still issues with string insertions into the tile URLs. On a Windows computer some zoom factor is inserted into the URL so the extension tries to access `https://tile.openstreetmap.org/12/2053/1365@1.3x.png?lang=en` instead of `https://tile.openstreetmap.org/12/2053/1365.png?lang=en`. AFAIK switching-off high-DPI should fix that.

The second addition configures the extension to stop requesting images for map pins from the tile servers. This behavior was mentioned at the [original proposal](https://github.com/openstreetmap/operations/issues/749) already. I found an previously undocumented setting that will use a static image included in the extension. 