### PR TITLE
Add Translate extension to Wiki

### DIFF
--- a/cookbooks/wiki/recipes/default.rb
+++ b/cookbooks/wiki/recipes/default.rb
@@ -122,6 +122,12 @@ mediawiki_extension "Kartographer" do
   template_cookbook "wiki"
 end
 
+mediawiki_extension "Translate" do
+  site "wiki.openstreetmap.org"
+  template "mw-ext-Translate.inc.php.erb"
+  template_cookbook "wiki"
+end
+
 cookbook_file "/srv/wiki.openstreetmap.org/osm_logo_wiki.png" do
   owner node[:mediawiki][:user]
   group node[:mediawiki][:group]

--- a/cookbooks/wiki/templates/default/mw-ext-Translate.inc.php.erb
+++ b/cookbooks/wiki/templates/default/mw-ext-Translate.inc.php.erb
@@ -1,0 +1,36 @@
+<?php
+# DO NOT EDIT - This file is being maintained by Chef
+
+wfLoadExtension( 'Translate' );
+$wgGroupPermissions['user']['translate'] = true;
+$wgGroupPermissions['user']['skipcaptcha'] = true; // Bug 34182: needed with ConfirmEdit
+
+/**
+ * Language code for message documentation. Suggested values are qqq or info.
+ * If set to false (default), message documentation feature is disabled.
+ */
+$wgTranslateDocumentationLanguageCode = 'qqq';
+
+$wgGroupPermissions['autoconfirmed']['translate-messagereview'] = true;
+
+$wgGroupPermissions['translationadmin']['pagetranslation'] = true;
+$wgGroupPermissions['translationadmin']['translate-manage'] = true;
+
+/**
+ * Add a preference "Do not send me email newsletters" in the email preferences.
+ */
+$wgTranslateNewsletterPreference = true;
+
+/** 
+ * Let Translate extension use ElasticSearch to store commonly-used translation messages to suggest to translators
+ */
+$wgTranslateTranslationServices['TTMServer'] = array(
+        'type' => 'ttmserver',
+        'class' => 'ElasticSearchTTMServer',
+        'cutoff' => 0.75,
+        /*
+         * See http://elastica.io/getting-started/installation.html
+         * See https://github.com/ruflin/Elastica/blob/8.x/src/Client.php
+         */
+       'config' => [ 'servers' => [ 'host' => '127.0.0.1', 'port' => 9114 ] ]
+);


### PR DESCRIPTION
This adds the Translate extension to the Wiki. 

All other [extension dependencies](https://www.mediawiki.org/wiki/MediaWiki_Language_Extension_Bundle) have already been installed so no other extensions are added as part of this request.

User rights and the new role of "translateadmin" have been [configured](https://www.mediawiki.org/wiki/Help:Extension:Translate/Configuration) according to the [original proposal](https://wiki.openstreetmap.org/wiki/Proposed_features/Add_Translate_extension_to_Wiki#Configuration).

The OSM ElasticSearch server will now be utilized for storing [translation memories](https://www.mediawiki.org/wiki/Help:Extension:Translate/Translation_memories).

Closes https://github.com/openstreetmap/operations/issues/649