### PR TITLE
Clarify licensing wording on planet.osm.org

### DIFF
--- a/cookbooks/planet/files/default/cgi/HEADER.cgi
+++ b/cookbooks/planet/files/default/cgi/HEADER.cgi
@@ -67,8 +67,7 @@ print("""
 <h1>Planet OSM</h1>
 
 <p>
-The files found here are regularly-updated, complete copies of the OpenStreetMap.org
-database, and those published before the 12 September 2012 are distributed under a Creative Commons Attribution-ShareAlike 2.0 license, those published after are  Open Data Commons Open Database License 1.0 licensed. For more information, <a href="https://wiki.openstreetmap.org/wiki/Planet.osm">see the project wiki</a>.
+The files found here are regularly-updated, complete copies of the <a href="https://openstreetmap.org">OpenStreetMap</a> database.
 </p>
 <p><div class="alert"><strong>WARNING</strong> Download speeds are currently restricted to 4096 KB/s due to limited available capacity on our Internet connection. <a href="https://wiki.openstreetmap.org/wiki/Planet.osm#BitTorrent">Please use torrents</a> or <a href="https://wiki.openstreetmap.org/wiki/Planet.osm#Planet.osm_mirrors">a mirror</a> if possible.</div></p>
 <table id="about">
@@ -90,32 +89,42 @@ database, and those published before the 12 September 2012 are distributed under
         <p>%(planet_pbf_link)s</p>
         <p>
         Each week, a new and complete copy of all data in OpenStreetMap is made
-        available as both a compressed XML file and a custom PBF format file.
+        available as both a compressed XML file and a more compact
+        <a href="https://wiki.openstreetmap.org/wiki/PBF_Format">custom PBF format</a> file.
         Also available is the <a href="planet/full-history">'history'</a> file
         which contains not only up-to-date data but also older versions of data
         and deleted data items.
-        <p>
         </p>
+        <p>
         A smaller file with complete metadata for all changes ('changesets') in
         XML format is also available.
         </p>
     </td>
     <td>
         <p>
-        You are granted permission to use OpenStreetMap data by
-        <a href="https://osm.org/copyright">the OpenStreetMap License</a>, which also describes
-        your obligations.
+        This open data is <a href="https://osm.org/copyright">provided by OpenStreetMap</a>.
+        You are granted permission to use the data under the
+        <a href="https://opendatacommons.org/licenses/odbl/">Open Database License 1.0</a>.
+        <a href="https://wiki.osmfoundation.org/wiki/Licence/Licence_and_Legal_FAQ">
+            More information on licensing
+        </a>.
+        </p>
+        <p class="aside">
+          (For exports published before 12 September 2012, the Creative Commons
+          Attribution-ShareAlike 2.0 license applies instead.) 
         </p>
         <p>
-        You can <a href="https://wiki.openstreetmap.org/wiki/Planet.osm#Processing_the_file">process the file</a>
-        or extracts with a variety of tools. <a href="https://wiki.openstreetmap.org/wiki/Osmosis">Osmosis</a>
-        is a general-purpose command-line tool for converting the data among different formats
-        and databases, and <a href="https://wiki.openstreetmap.org/wiki/Osm2pgsql">Osm2pgsql</a>
-        is a tool for importing the data into a Postgis database for rendering maps.
-        </p>
+        You can <a href="https://wiki.openstreetmap.org/wiki/Planet.osm#Processing_the_file">
+        process OpenStreetMap data</a> with a variety of tools, including:</p>
+        <ul>
+          <li><a href="https://wiki.openstreetmap.org/wiki/Osmosis">Osmosis</a>,
+            a general-purpose command-line tool for converting the data between different formats.</li>
+          <li><a href="https://wiki.openstreetmap.org/wiki/Osm2pgsql">Osm2pgsql</a>,
+            a tool for importing the data into a PostGIS database for rendering maps.</li>
+        </ul>
         <p>
-        <a href="https://osmdata.openstreetmap.de/">Processed coastline data</a>
-        derived from OSM data is also needed for rendering usable maps.
+        <a href="https://osmdata.openstreetmap.de/">Processed coastlines</a>
+        derived from OSM data are also needed for rendering usable maps.
         </p>
     </td>
     <td>


### PR DESCRIPTION
This contains only the content changes from #574 - a bit more info and screenshots of the updated wording can be found in that pull request.

The intention of this change is to make more explicit what license the data is distributed under, as this has apparently [caused confusion](https://lists.openstreetmap.org/pipermail/talk/2023-February/088042.html). It also adds the "Copyright OpenStreetMap" attribution link which I believe is technically needed here too.

It also includes some minor copy-editing.

(This change alone causes a slight layout glitch as the OSM logo overlaps the warning box. This is fixed in #574.)