### PR TITLE
tile: Serve a tilejson pointing at the correct tile URLs

### DIFF
--- a/cookbooks/tile/files/default/tilejson.json
+++ b/cookbooks/tile/files/default/tilejson.json
@@ -1,0 +1,10 @@
+{
+    "tilejson": "3.0.0",
+    "attribution": "© <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a> contributors",
+    "name": "OpenStreetMap Standard",
+    "tiles": [
+        "https://tile.openstreetmap.org/{z}/{x}/{y}.png"
+    ],
+    "minzoom": 0,
+    "maxzoom": 19
+}


### PR DESCRIPTION
In some tools it's useful to have a tilejson when adding a layer, so you can give the tool one URL, and it will automatically know the correct tile URLs, zoom range, attribution, and name.

I considered making this generated by chef, but decided against it for a few reasons
- It's a lot of additional complexity for a 236 byte file
- In practice, we would need to rewrite how we handle multiple styles if we ever wanted to do it, as they would need different URLs
- if we changed maxzoom, we would probably want to first change it in the render stack, then later on roll it to the tilejson
- if this file had existed a decade ago, the only change since then would be removing {a,b,c}. It doesn't change often

This will require changes on the CDN to allow the URL to reach the backend servers.