### PR TITLE
docker: Enable IPv6 support using ULA

### DIFF
--- a/cookbooks/community/templates/default/web_only.yml.erb
+++ b/cookbooks/community/templates/default/web_only.yml.erb
@@ -110,6 +110,7 @@ hooks:
         from: /listen 80;/
         to: |
           listen 80;
+          listen [::]:80;
           rewrite ^/\.well-known/acme-challenge/(.*)$ http://acme.openstreetmap.org/.well-known/acme-challenge/$1 permanent;
 
     - replace:

--- a/cookbooks/docker/recipes/default.rb
+++ b/cookbooks/docker/recipes/default.rb
@@ -39,6 +39,11 @@ template "/etc/docker/daemon.json" do
   mode "644"
 end
 
+service "containerd" do
+  action [:enable, :start]
+  subscribes :restart, "template[/etc/docker/daemon.json]"
+end
+
 service "docker" do
   action [:enable, :start]
   subscribes :restart, "template[/etc/docker/daemon.json]"

--- a/cookbooks/docker/templates/default/daemon.json.erb
+++ b/cookbooks/docker/templates/default/daemon.json.erb
@@ -4,5 +4,9 @@
   "log-opts": {
     "max-size": "100m"
   },
-  "storage-driver": "overlay2"
+  "storage-driver": "overlay2",
+  "experimental": true,
+  "ipv6": true,
+  "ip6tables": true,
+  "fixed-cidr-v6": "fd9e:d0ce:beef::/48"
 }


### PR DESCRIPTION
Uses the experimental `ip6tables` feature which isn't ideal, but seems to work ok.

Fixes: [#843](https://github.com/openstreetmap/operations/issues/843)