### PR TITLE
networking: allow opportunistic DNS Over TLS

### DIFF
--- a/cookbooks/networking/attributes/default.rb
+++ b/cookbooks/networking/attributes/default.rb
@@ -8,9 +8,18 @@ default[:networking][:firewall][:http_connection_limit] = nil
 default[:networking][:firewall][:allowlist] = []
 default[:networking][:roles] = {}
 default[:networking][:interfaces] = {}
-default[:networking][:nameservers] = %w[8.8.8.8 8.8.4.4 2001:4860:4860::8888 2001:4860:4860::8844]
+default[:networking][:nameservers] = %w[1.1.1.1#cloudflare-dns.com 1.0.0.1#cloudflare-dns.com 2606:4700:4700::1111#cloudflare-dns.com 2606:4700:4700::1001#cloudflare-dns.com 8.8.8.8#dns.google 8.8.4.4#dns.google 2001:4860:4860::8888#dns.google 2001:4860:4860::8844#dns.google 9.9.9.9#dns.quad9.net 149.112.112.112#dns.quad9.net 2620:fe::fe#dns.quad9.net 2620:fe::9#dns.quad9.net]
 default[:networking][:search] = []
 default[:networking][:dnssec] = "allow-downgrade"
+
+default[:networking][:dnsovertls] = if platform?("debian")
+                                      "opportunistic"
+                                    elsif node[:lsb][:release].to_f < 22.04
+                                      "no"
+                                    else
+                                      "opportunistic"
+                                    end
+
 default[:networking][:hostname] = node.name
 default[:networking][:wireguard][:enabled] = true
 default[:networking][:wireguard][:keepalive] = 180

--- a/cookbooks/networking/templates/default/resolved.conf.erb
+++ b/cookbooks/networking/templates/default/resolved.conf.erb
@@ -1,5 +1,6 @@
 [Resolve]
 DNS=<%= node[:networking][:nameservers].join(" ") %>
-FallbackDNS=1.1.1.1 9.9.9.10 8.8.8.8 2606:4700:4700::1111 2620:fe::10 2001:4860:4860::8888
+FallbackDNS=1.1.1.1#cloudflare-dns.com 1.0.0.1#cloudflare-dns.com 2606:4700:4700::1111#cloudflare-dns.com 2606:4700:4700::1001#cloudflare-dns.com 8.8.8.8#dns.google 8.8.4.4#dns.google 2001:4860:4860::8888#dns.google 2001:4860:4860::8844#dns.google 9.9.9.9#dns.quad9.net 149.112.112.112#dns.quad9.net 2620:fe::fe#dns.quad9.net 2620:fe::9#dns.quad9.net
 Domains=<%= node[:networking][:search].join(" ") %>
 DNSSEC=<%= node[:networking][:dnssec] %>
+DNSOverTLS=<%= node[:networking][:dnsovertls] %>


### PR DESCRIPTION
Bringing back this PR. Without is most kitchen runs fail locally for me due to DNS failure.

DNS over TLS seems to be well supported in recent systemd-resolved

In limited testing DNS over TLS seems to work more consistently than standard DNS when IPv6 and/or DNSSEC are not functioning correctly (DNSSEC fallback).