### PR TITLE
Update to tilelog 1.6.0 and generate new tables

### DIFF
--- a/cookbooks/tilelog/recipes/default.rb
+++ b/cookbooks/tilelog/recipes/default.rb
@@ -31,7 +31,7 @@ end
 python_package "tilelog" do
   python_virtualenv tilelog_directory
   python_version "3"
-  version "1.5.0"
+  version "1.6.0"
 end
 
 directory tilelog_output_directory do

--- a/cookbooks/tilelog/templates/default/tilelog.erb
+++ b/cookbooks/tilelog/templates/default/tilelog.erb
@@ -20,7 +20,8 @@ HOSTFILE="hosts-${DATE}.csv"
 APPFILE="apps-${DATE}.csv"
 COUNTRYFILE="countries-${DATE}.csv"
 
-nice -n 19 /opt/tilelog/bin/tilelog --date "${DATE}" --generate-success \
+nice -n 19 /opt/tilelog/bin/tilelog --date "${DATE}" \
+  --generate-success --generate-minimise --generate-location \
   --tile "${TILEFILE}" --host "${HOSTFILE}" --app "${APPFILE}" --country "${COUNTRYFILE}"
 
 mv "${TILEFILE}" "${HOSTFILE}" "${APPFILE}" "${COUNTRYFILE}" "${OUTDIR}"


### PR DESCRIPTION
These new tables allow for generalization of data and reducing the data stored. They're not yet queried, that will come in a later version, but this allows population of the tables to start.