### PR TITLE
Update to tilelog 1.6.1

### DIFF
--- a/cookbooks/tilelog/recipes/default.rb
+++ b/cookbooks/tilelog/recipes/default.rb
@@ -31,7 +31,7 @@ end
 python_package "tilelog" do
   python_virtualenv tilelog_directory
   python_version "3"
-  version "1.6.0"
+  version "1.6.1"
 end
 
 directory tilelog_output_directory do


### PR DESCRIPTION
The queries on 1.6.0 were running into resource limits when aggregating on busy days. This changes them to split up the work by hour.