### PR TITLE
postgres: explicitly specifiy WAL-G compressor

### DIFF
--- a/cookbooks/db/templates/default/wal-g.erb
+++ b/cookbooks/db/templates/default/wal-g.erb
@@ -2,7 +2,8 @@
 
 # DO NOT EDIT - This file is being maintained by Chef
 
-export WALE_S3_PREFIX="s3://openstreetmap-wal/"
+export WALG_S3_PREFIX="s3://openstreetmap-wal/"
+export WALG_COMPRESSION_METHOD="lz4"
 export AWS_ACCESS_KEY_ID="AKIAIQX2LTDOBIW4CZUQ"
 export AWS_SECRET_ACCESS_KEY="<%= @s3_key %>"
 export AWS_REGION="eu-west-2"


### PR DESCRIPTION
WAL-G uploads LZ4 by default, but seem to cycle through the supported compressors when downloading.

Extract from Cloudwatch logs
```
"arn:aws:s3:::openstreetmap-wal/wal_005/000000010001016A00000058.lzma" (GET 404)
"arn:aws:s3:::openstreetmap-wal/wal_005/000000010001016A00000058.lz4" (PUT)
"arn:aws:s3:::openstreetmap-wal/wal_005/000000010001016A00000058.gz" (GET 404)
"arn:aws:s3:::openstreetmap-wal/wal_005/000000010001016A00000058.br" (GET 404)
"arn:aws:s3:::openstreetmap-wal/wal_005/000000010001016A00000058.lzo" (GET 404)
"arn:aws:s3:::openstreetmap-wal/wal_005/000000010001016A00000058.zst" (GET 404)
"arn:aws:s3:::openstreetmap-wal/wal_005/000000010001016A00000058.lz4" (GET 200)
```

Try explicitly set `WALG_COMPRESSION_METHOD` in an attempt to stop this behaviour.
Also renamed `WALE_S3_PREFIX` -> `WALG_S3_PREFIX` (E -> G)