### PR TITLE
Update yarnpkg APT signing key

### DIFF
--- a/cookbooks/apt/recipes/yarn.rb
+++ b/cookbooks/apt/recipes/yarn.rb
@@ -23,5 +23,5 @@ apt_repository "yarn" do
   uri "https://dl.yarnpkg.com/debian"
   distribution "stable"
   components ["main"]
-  key "23E7166788B63E1E"
+  key "1646B01B86E50310"
 end


### PR DESCRIPTION
`apt update` was complaining about an expired key. I checked the setup instructions and found the key has changed, and got the new one with `curl -s https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --show-keys --with-colons - | awk -F':' '$1=="pub"{print $5}'`

I validated this from two machines for paranoia.