### PR TITLE
Use GHCR dokken images in test kitchen

### DIFF
--- a/.github/workflows/test-kitchen.yml
+++ b/.github/workflows/test-kitchen.yml
@@ -128,6 +128,12 @@ jobs:
             os: ubuntu-2204
       fail-fast: false
     steps:
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     - name: Check out code
       uses: actions/checkout@v3
     - name: Setup ruby

--- a/.github/workflows/test-kitchen.yml
+++ b/.github/workflows/test-kitchen.yml
@@ -13,6 +13,8 @@ jobs:
   kitchen:
     name: Test Kitchen
     runs-on: ubuntu-22.04
+    permissions:
+      packages: read
     strategy:
       matrix:
         suite:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -32,7 +32,7 @@ verifier:
 platforms:
   - name: ubuntu-20.04
     driver:
-      image: dokken/ubuntu-20.04
+      image: ghcr.io/test-kitchen/dokken/ubuntu-20.04
       privileged: true
       pid_one_command: /bin/systemd
       intermediate_instructions:
@@ -41,7 +41,7 @@ platforms:
         - RUN echo libeatmydata.so >>/etc/ld.so.preload
   - name: ubuntu-22.04
     driver:
-      image: dokken/ubuntu-22.04
+      image: ghcr.io/test-kitchen/dokken/ubuntu-22.04
       privileged: true
       pid_one_command: /bin/systemd
       intermediate_instructions:
@@ -50,7 +50,7 @@ platforms:
         - RUN echo libeatmydata.so >>/etc/ld.so.preload
   - name: debian-12
     driver:
-      image: dokken/debian-12
+      image: ghcr.io/test-kitchen/dokken/debian-12
       privileged: true
       pid_one_command: /bin/systemd
       intermediate_instructions:


### PR DESCRIPTION
Switch to GHCR.io dokken images for improved image download latency and to avoid potential docker hub access limits.