### PR TITLE
Add allow wiki main page on root + osmf site url change

### DIFF
--- a/cookbooks/foundation/recipes/wiki.rb
+++ b/cookbooks/foundation/recipes/wiki.rb
@@ -21,8 +21,8 @@ include_recipe "mediawiki"
 
 passwords = data_bag_item("foundation", "passwords")
 
-mediawiki_site "wiki.osmfoundation.org" do
-  aliases ["www.osmfoundation.org", "osmfoundation.org",
+mediawiki_site "osmfoundation.org" do
+  aliases ["wiki.osmfoundation.org", "www.osmfoundation.org",
            "foundation.openstreetmap.org", "foundation.osm.org"]
   sitename "OpenStreetMap Foundation"
   directory "/srv/wiki.osmfoundation.org"

--- a/cookbooks/mediawiki/templates/default/apache.erb
+++ b/cookbooks/mediawiki/templates/default/apache.erb
@@ -39,9 +39,7 @@
   RewriteCond %{SERVER_NAME} !=<%= @name %>
   RewriteRule ^/(.*)$ https://<%= @name %>/$1 [R=permanent]
 
-  RedirectMatch 301 ^/$                           /wiki/Main_Page
-
-  #Historical Compatibility Links
+  # Historical Compatibility Links
   RedirectMatch 301 ^/index\.php$                 /w/index.php
   RedirectMatch 301 ^/index\.php/(.*)$            /wiki/$1
   RedirectMatch 301 ^/skins/(.*)$                 /w/skins/$1
@@ -49,7 +47,7 @@
   RedirectMatch 301 ^/api\.php$                   /w/api.php
   RedirectMatch 301 ^/opensearch_desc\.php$       /w/opensearch_desc.php
 
-  #Support Wikidata redirects based on Wikimedia's redirects:
+  # Support Wikidata redirects based on Wikimedia's redirects:
   # https://github.com/wikimedia/puppet/blob/production/modules/mediawiki/files/apache/sites/wikidata-uris.incl
   RedirectMatch 301 ^/entity/statement/([QqPp]\d+).*$        /wiki/Special:EntityData/$1
   RedirectMatch 301 ^/value/(.*)$                            /wiki/Special:ListDatatypes
@@ -71,8 +69,9 @@
 
   Alias /wiki <%= @directory %>/w/index.php
 
-  #Support /pagename -> /wiki/pagename
+  # Support /pagename -> /wiki/pagename
   RewriteEngine on
+  RewriteRule ^/$ /w/index.php?title=Main_Page [L,QSA]
   RewriteCond %{REQUEST_URI} !^/w/
   RewriteCond %{REQUEST_URI} !^/wiki/
   RewriteCond %{REQUEST_URI} !^/index\.php
@@ -83,8 +82,8 @@
   RewriteCond %{REQUEST_URI} !^/entity/
   RewriteCond %{REQUEST_URI} !^/value/
   RewriteCond %{REQUEST_URI} !^/reference/
-  RewriteCond %{REQUEST_URI} !^/prop/  
-  RewriteCond %{REQUEST_URI} !^/dump/  
+  RewriteCond %{REQUEST_URI} !^/prop/
+  RewriteCond %{REQUEST_URI} !^/dump/
   RewriteCond %{REQUEST_URI} !^/server-status
   RewriteCond %{REQUEST_URI} !^/.well-known/
   RewriteCond %{LA-U:REQUEST_FILENAME} !-f


### PR DESCRIPTION
This change changes https://wiki.osmfoundation.org/ site to https://osmfoundation.org/

Allows / to serve /wiki/Main_Page without a redirect.