### PR TITLE
Add exception handling for fdirsync replicate-changesets

### DIFF
--- a/cookbooks/planet/files/default/replication-bin/replicate-changesets
+++ b/cookbooks/planet/files/default/replication-bin/replicate-changesets
@@ -127,10 +127,15 @@ end
 # sync a directory to guarantee it's on disk. have to recurse to the root
 # to guarantee sync for newly created directories.
 def fdirsync(d)
+  d = File.realpath(d)
   while d != "/"
-    Dir.open(d) do |dh|
-      io = IO.for_fd(dh.fileno)
-      io.fsync
+    begin
+      Dir.open(d) do |dh|
+        io = IO.for_fd(dh.fileno)
+        io.fsync
+      end
+    rescue SystemCallError => e
+      warn "Error! syncing directory #{d}: #{e.message}"
     end
     d = File.dirname(d)
   end


### PR DESCRIPTION
Every few days call to `fdirsync()` function of `replicate-changesets` throws a `Bad file descriptor` exception while running the `io.fsync` (line: 133).

The exception terminates the script and the `aws s3 cp` does not run.

Add exception handler to catch (and ignore) the exception and output which directory is causing the issue for potential further investigation.