### PR TITLE
render: Run lowzoom daily

### DIFF
--- a/cookbooks/tile/recipes/default.rb
+++ b/cookbooks/tile/recipes/default.rb
@@ -614,7 +614,7 @@ end
 
 systemd_timer "render-lowzoom" do
   description "Render low zoom tiles"
-  on_calendar "Fri *-*-* 23:00:00 UTC"
+  on_calendar "*-*-* 23:00:00 UTC"
 end
 
 service "render-lowzoom.timer" do


### PR DESCRIPTION
Now that renderd is significantly faster, it becomes practical to run lowzoom updates daily.