### PR TITLE
Freeze mutable objects assigned to constants

### DIFF
--- a/cookbooks/db/recipes/master.rb
+++ b/cookbooks/db/recipes/master.rb
@@ -117,13 +117,13 @@ CGIMAP_PERMISSIONS = {
   "way_nodes" => [:select, :insert],
   "way_tags" => [:select, :insert],
   "ways" => [:select, :insert]
-}
+}.freeze
 
 PLANETDUMP_PERMISSIONS = {
   "note_comments" => :select,
   "notes" => :select,
   "users" => :select
-}
+}.freeze
 
 PLANETDIFF_PERMISSIONS = {
   "changeset_comments" => :select,
@@ -138,7 +138,7 @@ PLANETDIFF_PERMISSIONS = {
   "way_nodes" => :select,
   "way_tags" => :select,
   "ways" => :select
-}
+}.freeze
 
 %w[
   acls


### PR DESCRIPTION
Fixes cookstyle complaint:

...............................................................C.....................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Offenses:

cookbooks/db/recipes/master.rb:87:22: C: [Correctable] Style/MutableConstant: Freeze mutable objects assigned to constants. CGIMAP_PERMISSIONS = { ...
                     ^
cookbooks/db/recipes/master.rb:122:26: C: [Correctable] Style/MutableConstant: Freeze mutable objects assigned to constants. PLANETDUMP_PERMISSIONS = { ...
                         ^
cookbooks/db/recipes/master.rb:128:26: C: [Correctable] Style/MutableConstant: Freeze mutable objects assigned to constants. PLANETDIFF_PERMISSIONS = { ...
                         ^

597 files inspected, 3 offenses detected, 3 offenses auto-correctable