### PR TITLE
Add test for chef cookbook

### DIFF
--- a/.github/workflows/test-kitchen.yml
+++ b/.github/workflows/test-kitchen.yml
@@ -25,6 +25,7 @@ jobs:
           - bind
           - blog
           - blogs
+          - chef
           - civicrm
           - clamav
           - community

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -86,6 +86,9 @@ suites:
   - name: blogs
     run_list:
       - recipe[blogs::default]
+  - name: chef
+    run_list:
+      - recipe[chef::default]
   - name: civicrm
     run_list:
       - recipe[civicrm::default]

--- a/test/integration/chef/inspec/chef_spec.rb
+++ b/test/integration/chef/inspec/chef_spec.rb
@@ -1,0 +1,17 @@
+describe package("chef") do
+  it { should be_installed }
+end
+
+describe systemd_service("chef-client") do
+  it { should be_installed }
+end
+
+describe systemd_service("chef-client.timer") do
+  it { should be_installed }
+  it { should be_enabled }
+end
+
+describe command("chef-client --version") do
+  its("exit_status") { should eq 0 }
+  its("stdout") { should match /Chef Infra Client/ }
+end


### PR DESCRIPTION
Add basic chef test to chef service + timer installed and the binary functions.

Added workaround for missing Debian ARM builds by using ARM build from Ubuntu.