### PR TITLE
apache: disable mod_evasive

### DIFF
--- a/cookbooks/apache/attributes/default.rb
+++ b/cookbooks/apache/attributes/default.rb
@@ -30,7 +30,7 @@ default[:apache][:listen_address] = "*"
 
 default[:apache][:buffered_logs] = true
 
-default[:apache][:evasive][:enable] = true
+default[:apache][:evasive][:enable] = false
 default[:apache][:evasive][:hash_table_size] = 65536
 default[:apache][:evasive][:page_count] = 50
 default[:apache][:evasive][:site_count] = 250


### PR DESCRIPTION
mod_evasive is a heavy hammer. At the moment it requires further tuning to avoid false positives. Further experimentation is required to see if a suitable solution can be found.