### PR TITLE
apache: increase mod_evasive page_count to reduce iD false positives

### DIFF
--- a/cookbooks/apache/attributes/default.rb
+++ b/cookbooks/apache/attributes/default.rb
@@ -32,7 +32,8 @@ default[:apache][:buffered_logs] = true
 
 default[:apache][:evasive][:enable] = true
 default[:apache][:evasive][:hash_table_size] = 65536
-default[:apache][:evasive][:page_count] = 50
+# page_count is misnomer as it can match backends in some cases
+default[:apache][:evasive][:page_count] = 150
 default[:apache][:evasive][:site_count] = 250
 default[:apache][:evasive][:page_interval] = 1
 default[:apache][:evasive][:site_interval] = 1


### PR DESCRIPTION
iD tiles map requests.

It appears 4x3 tiles are common, 12 requests + 12 CORS requests. (24 req)
If the user also scrolls the map this can exceed current 50 req/s.