### PR TITLE
otrs: upgrade to latest znuny 6.0.x release

### DIFF
--- a/cookbooks/otrs/attributes/default.rb
+++ b/cookbooks/otrs/attributes/default.rb
@@ -1,4 +1,4 @@
-default[:otrs][:version] = "6.0.30"
+default[:otrs][:version] = "6.0.48"
 default[:otrs][:user] = "otrs"
 default[:otrs][:group] = nil
 default[:otrs][:database_cluster] = "15/main"

--- a/cookbooks/otrs/templates/default/sudoers.erb
+++ b/cookbooks/otrs/templates/default/sudoers.erb
@@ -1,4 +1,0 @@
-# DO NOT EDIT - This file is being maintained by Chef
-
-# Allow exim to deliver mail into OTRS
-Debian-exim ALL=(otrs) NOPASSWD: /usr/share/otrs/bin/PostMaster.pl


### PR DESCRIPTION
znuny only supports upgrading one minor version at a time. Future upgrades will be 6.0.x -> 6.1.x -> 6.2.x etc