### PR TITLE
dhcpd: set ignore-client-uids to ensure consistent DHCP IPs

### DIFF
--- a/cookbooks/dhcpd/templates/default/dhcpd.conf.erb
+++ b/cookbooks/dhcpd/templates/default/dhcpd.conf.erb
@@ -21,6 +21,9 @@ subnet <%= address.network %> netmask <%= address.netmask %> {
   option PCode "UTC0";
   option TCode "Etc/UTC";
 
+  # Ensure PXE and systemd-networkd are given the same IP address
+  ignore-client-uids true;
+
   next-server <%= address.gateway %>;
 
   # See https://netboot.xyz/docs/docker/#dhcp-configurations


### PR DESCRIPTION
Without this fix systemd-networkd, PXE, dhclient etc may be given different IPs because of generated client uid mismatches.