### PR TITLE
otrs: Add otrs::debian for installing otrs via deb package

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -280,6 +280,9 @@ suites:
   - name: otrs
     run_list:
       - recipe[otrs::default]
+  - name: otrs-debian
+    run_list:
+      - recipe[otrs::debian]
   - name: overpass
     run_list:
       - recipe[overpass::default]

--- a/cookbooks/otrs/recipes/debian.rb
+++ b/cookbooks/otrs/recipes/debian.rb
@@ -1,0 +1,121 @@
+#
+# Cookbook:: otrs
+# Recipe:: debian
+#
+# Copyright:: 2024, OpenStreetMap Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe "accounts"
+include_recipe "apache"
+include_recipe "exim"
+include_recipe "postgresql"
+include_recipe "tools"
+
+passwords = data_bag_item("otrs", "passwords")
+
+apache_module "perl" do
+  package "libapache2-mod-perl2"
+end
+
+apache_module "deflate"
+apache_module "headers"
+apache_module "rewrite"
+
+database_cluster = node[:otrs][:database_cluster]
+database_name = node[:otrs][:database_name]
+database_user = node[:otrs][:database_user]
+database_password = passwords[node[:otrs][:database_password]]
+site = node[:otrs][:site]
+site_aliases = node[:otrs][:site_aliases] || []
+
+postgresql_user database_user do
+  cluster database_cluster
+  password database_password
+end
+
+postgresql_database database_name do
+  cluster database_cluster
+  owner database_user
+end
+
+package "dbconfig-common"
+
+template "/etc/dbconfig-common/otrs2.conf" do
+  source "dbconfig.config.erb"
+  owner "root"
+  group "root"
+  mode "600"
+  variables :database_name => database_name,
+            :database_user => database_user,
+            :database_password => database_password
+end
+
+apt_package "otrs2" do
+  options "-t #{node[:lsb][:codename]}-backports"
+end
+
+# Ensure debconf is repopulated on a dbconfig change
+execute "dpkg-reconfigure-otrs2" do
+  action :nothing
+  command "dpkg-reconfigure -fnoninteractive otrs2"
+  subscribes :run, "template[/etc/dbconfig-common/otrs2.conf]"
+end
+
+# Disable deb otrs2 apache config
+apache_conf "otrs2" do
+  action :disable
+end
+
+# Disable deb otrs2 cron job
+file "/etc/cron.d/otrs2" do
+  action :delete
+  manage_symlink_source true
+end
+
+systemd_service "otrs" do
+  description "OTRS Daemon"
+  type "forking"
+  user "otrs"
+  group "otrs"
+  exec_start_pre "-/usr/share/otrs/bin/otrs.Daemon.pl stop" # Stop if race with deb cron
+  exec_start "/usr/share/otrs/bin/otrs.Daemon.pl start"
+  private_tmp true
+  protect_system "strict"
+  protect_home true
+  read_write_paths ["/var/lib/otrs", "/var/log/exim4", "/var/spool/exim4"]
+end
+
+service "otrs" do
+  action [:enable, :start]
+  subscribes :restart, "apt_package[otrs2]"
+  subscribes :restart, "systemd_service[otrs]"
+end
+
+ssl_certificate site do
+  domains [site] + site_aliases
+  notifies :reload, "service[apache2]"
+end
+
+apache_site site do
+  template "apache-debian.erb"
+  variables :aliases => site_aliases
+end
+
+template "/etc/cron.daily/otrs-backup" do
+  source "backup.cron.erb"
+  owner "root"
+  group "root"
+  mode "755"
+end

--- a/cookbooks/otrs/templates/default/apache-debian.erb
+++ b/cookbooks/otrs/templates/default/apache-debian.erb
@@ -1,0 +1,114 @@
+# DO NOT EDIT - This file is being maintained by Chef
+
+<VirtualHost *:80>
+  ServerName <%= @name %>
+<% @aliases.each do |alias_name| -%>
+  ServerAlias <%= alias_name %>
+<% end -%>
+  ServerAdmin webmaster@openstreetmap.org
+
+  CustomLog /var/log/apache2/<%= @name %>-access.log combined_extended
+  ErrorLog /var/log/apache2/<%= @name %>-error.log
+
+  RedirectPermanent /.well-known/acme-challenge/ http://acme.openstreetmap.org/.well-known/acme-challenge/
+  RedirectPermanent / https://<%= @name %>/
+</VirtualHost>
+<% unless @aliases.empty? -%>
+
+<VirtualHost *:443>
+  ServerName <%= @aliases.first %>
+<% @aliases.drop(1).each do |alias_name| -%>
+  ServerAlias <%= alias_name %>
+<% end -%>
+  ServerAdmin webmaster@openstreetmap.org
+
+  SSLEngine on
+  SSLCertificateFile /etc/ssl/certs/<%= @name %>.pem
+  SSLCertificateKeyFile /etc/ssl/private/<%= @name %>.key
+
+  CustomLog /var/log/apache2/<%= @name %>-access.log combined_extended
+  ErrorLog /var/log/apache2/<%= @name %>-error.log
+
+  RedirectPermanent / https://<%= @name %>/
+</VirtualHost>
+<% end -%>
+
+<VirtualHost *:443>
+  ServerName <%= @name %>
+  ServerAdmin webmaster@openstreetmap.org
+
+  CustomLog /var/log/apache2/<%= @name %>-access.log combined_extended
+  ErrorLog /var/log/apache2/<%= @name %>-error.log
+
+  SSLEngine on
+  SSLCertificateFile /etc/ssl/certs/<%= @name %>.pem
+  SSLCertificateKeyFile /etc/ssl/private/<%= @name %>.key
+
+  ScriptAlias /otrs "/usr/share/otrs/bin/cgi-bin/"
+  Alias /otrs-web "/usr/share/otrs/var/httpd/htdocs/"
+  RedirectMatch ^/$ /otrs/index.pl
+
+  Perlrequire /usr/share/otrs/scripts/apache2-perl-startup.pl
+
+  PerlModule Apache2::Reload
+  PerlInitHandler Apache2::Reload
+
+
+  <Location /otrs>
+    ErrorDocument 403 /otrs/index.pl
+		ErrorDocument 404 /otrs/index.pl
+    SetHandler  perl-script
+    PerlResponseHandler ModPerl::Registry
+    Options +ExecCGI
+    PerlOptions +ParseHeaders
+    PerlOptions +SetupEnv
+    Require all granted
+  </Location>
+
+  <Location /otrs/nph-genericinterface.pl>
+    PerlOptions -ParseHeaders
+  </Location>
+</VirtualHost>
+
+<Directory "/usr/share/otrs/bin/cgi-bin/">
+    AllowOverride None
+    Options +ExecCGI -Includes
+    Require all granted
+</Directory>
+
+<Directory "/usr/share/otrs/var/httpd/htdocs/">
+  AllowOverride None
+  Require all granted
+
+  # Make sure CSS and JS files are read as UTF8 by the browsers.
+  AddCharset UTF-8 .css
+  AddCharset UTF-8 .js
+
+  # Set explicit mime type for woff fonts since it is relatively new and apache may not know about it.
+  AddType application/font-woff .woff
+</Directory>
+
+# Cache css-cache for 30 days
+<Directory "/usr/share/otrs/var/httpd/htdocs/skins/*/*/css-cache">
+    <FilesMatch "\.(css|CSS)$">
+        Header set Cache-Control "max-age=2592000, must-revalidate"
+    </FilesMatch>
+</Directory>
+
+<Directory "/usr/share/otrs/var/httpd/htdocs/skins/*/*/css/thirdparty">
+    <FilesMatch "\.(css|CSS|woff|svg)$">
+        Header set Cache-Control "max-age=14400, must-revalidate"
+    </FilesMatch>
+</Directory>
+
+<Directory "/usr/share/otrs/var/httpd/htdocs/js/js-cache">
+    <FilesMatch "\.(js|JS)$">
+        Header set Cache-Control "max-age=2592000, must-revalidate"
+    </FilesMatch>
+</Directory>
+
+<Directory "/usr/share/otrs/var/httpd/htdocs/js/thirdparty/">
+    <FilesMatch "\.(js|JS)$">
+        Header set Cache-Control "max-age=14400, must-revalidate"
+    </FilesMatch>
+</Directory>

--- a/cookbooks/otrs/templates/default/dbconfig.config.erb
+++ b/cookbooks/otrs/templates/default/dbconfig.config.erb
@@ -1,0 +1,83 @@
+# DO NOT EDIT - This file is being maintained by Chef
+
+# dbc_install: configure database with dbconfig-common?
+#              set to anything but "true" to opt out of assistance
+dbc_install='true'
+
+# dbc_upgrade: upgrade database with dbconfig-common?
+#              set to anything but "true" to opt out of assistance
+dbc_upgrade='true'
+
+# dbc_remove: deconfigure database with dbconfig-common?
+#             set to anything but "true" to opt out of assistance
+dbc_remove='false'
+
+# dbc_dbtype: type of underlying database to use
+#	this exists primarily to let dbconfig-common know what database
+#	type to use when a package supports multiple database types.
+#	don't change this value unless you know for certain that this
+#	package supports multiple database types
+dbc_dbtype='pgsql'
+
+# dbc_dbuser: database user
+#	the name of the user who we will use to connect to the database.
+dbc_dbuser='<%= @database_user %>'
+
+# dbc_dbpass: database user password
+#	the password to use with the above username when connecting
+#	to a database, if one is required
+dbc_dbpass='<%= @database_password %>'
+
+# dbc_dballow: allowed host to connect from
+#       only for database types that support specifying the host from
+#       which the database user is allowed to connect from
+#       this string defines for which host the dbc_dbuser is allowed
+#       to connect
+#       this value is only really used again when you reconfigure the
+#       package
+dbc_dballow='localhost'
+
+# dbc_dbserver: database host.
+#	leave unset to use localhost (or a more efficient local method
+#	if it exists).
+dbc_dbserver='localhost'
+
+# dbc_dbport: remote database port
+#	leave unset to use the default.  only applicable if you are
+#	using a remote database.
+dbc_dbport=''
+
+# dbc_dbname: name of database
+#	this is the name of your application's database.
+dbc_dbname='<%= @database_name %>'
+
+# dbc_dbadmin: name of the administrative user
+#	this is the administrative user that is used to create all of the above
+#	The exception is the MySQL/MariaDB localhost case, where this value is
+#	ignored and instead is determined from /etc/mysql/debian.cnf.
+dbc_dbadmin='postgres'
+
+# dbc_basepath: base directory to hold database files
+#	leave unset to use the default.  only applicable if you are
+#	using a local (filesystem based) database.
+dbc_basepath=''
+
+##
+## postgresql specific settings.  if you don't use postgresql,
+## you can safely ignore all of these
+##
+
+# dbc_ssl: should we require ssl?
+#	set to "true" to require that connections use ssl
+dbc_ssl=''
+
+# dbc_authmethod_admin: authentication method for admin
+# dbc_authmethod_user: authentication method for dbuser
+#	see the section titled "AUTHENTICATION METHODS" in
+#	/usr/share/doc/dbconfig-common/README.pgsql for more info
+dbc_authmethod_admin='ident'
+dbc_authmethod_user='password'
+
+##
+## end postgresql specific settings
+##

--- a/test/data_bags/otrs-debian/passwords.json
+++ b/test/data_bags/otrs-debian/passwords.json
@@ -1,0 +1,4 @@
+{
+  "id": "passwords",
+  "otrs": "database-password"
+}

--- a/test/integration/otrs-debian/inspec/apache_spec.rb
+++ b/test/integration/otrs-debian/inspec/apache_spec.rb
@@ -1,0 +1,18 @@
+describe package("apache2") do
+  it { should be_installed }
+end
+
+describe service("apache2") do
+  it { should be_enabled }
+  it { should be_running }
+end
+
+describe port(80) do
+  it { should be_listening }
+  its("protocols") { should cmp "tcp" }
+end
+
+describe port(443) do
+  it { should be_listening }
+  its("protocols") { should cmp "tcp" }
+end


### PR DESCRIPTION
Add chef cookbook `otrs::debian` for installing OTRS/Znuny from debian's otrs2/znuny package.