### PR TITLE
systemd-networkd-wait-online waiting for timeout in dokken

### DIFF
--- a/cookbooks/networking/recipes/default.rb
+++ b/cookbooks/networking/recipes/default.rb
@@ -266,6 +266,16 @@ if node[:networking][:wireguard][:enabled]
   end
 end
 
+# Setup dokken network in systemd-networkd to avoid systemd-networkd-wait-online delay
+template "/etc/systemd/network/dokken.network" do
+  source "dokken.network.erb"
+  owner "root"
+  group "root"
+  mode "644"
+  notifies :run, "execute[networkctl-reload]", :immediately
+  only_if { kitchen? }
+end
+
 notify_group "networkctl-reload"
 
 execute "networkctl-reload" do

--- a/cookbooks/networking/templates/default/dokken.network.erb
+++ b/cookbooks/networking/templates/default/dokken.network.erb
@@ -1,0 +1,10 @@
+[Match]
+Name=eth0
+
+[Link]
+RequiredForOnline=routable
+
+[Network]
+DHCP=no
+LinkLocalAddressing=no
+KeepConfiguration=yes


### PR DESCRIPTION
This lets `systemd-networkd` think it is managing the networking in podman / docker and ensures that `systemd-networkd-wait-online` does not wait for timeout on systemd services which rely on networking.