### PR TITLE
Sparse clone the prometheus-exporters repo

### DIFF
--- a/cookbooks/prometheus/recipes/default.rb
+++ b/cookbooks/prometheus/recipes/default.rb
@@ -46,6 +46,13 @@ directory "/opt/prometheus" do
   recursive true
 end
 
+execute "git-sparse-clone-prometheus-exporters" do
+  command "git clone --depth 1 --filter=blob:none --sparse https://github.com/openstreetmap/prometheus-exporters.git /opt/prometheus-exporters"
+  user "root"
+  group "root"
+  not_if { (platform?("ubuntu") && node[:lsb][:release].to_f < 22.04) || ::File.exist?("/opt/prometheus-exporters") }
+end
+
 git "/opt/prometheus-exporters" do
   action :sync
   repository "https://github.com/openstreetmap/prometheus-exporters.git"

--- a/cookbooks/prometheus/resources/collector.rb
+++ b/cookbooks/prometheus/resources/collector.rb
@@ -35,6 +35,14 @@ property :protect_clock, [true, false]
 property :protect_kernel_modules, [true, false]
 
 action :create do
+  execute "git-sparse-checkout-#{new_resource.collector}-collectors" do
+    command "git sparse-checkout add collectors/#{new_resource.collector}"
+    cwd "/opt/prometheus-exporters"
+    user "root"
+    group "root"
+    not_if { (platform?("ubuntu") && node[:lsb][:release].to_f < 22.04) || ::File.exist?("/opt/prometheus-exporters/collectors/#{new_resource.collector}") }
+  end
+
   systemd_service service_name do
     description "Prometheus #{new_resource.collector} collector"
     type "oneshot"

--- a/cookbooks/prometheus/resources/exporter.rb
+++ b/cookbooks/prometheus/resources/exporter.rb
@@ -68,6 +68,14 @@ action :create do
     end
   end
 
+  execute "git-sparse-checkout-#{new_resource.exporter}-exporters" do
+    command "git sparse-checkout add exporters/#{new_resource.exporter}"
+    cwd "/opt/prometheus-exporters"
+    user "root"
+    group "root"
+    not_if { (platform?("ubuntu") && node[:lsb][:release].to_f < 22.04) || ::File.exist?("/opt/prometheus-exporters/exporters/#{new_resource.exporter}") }
+  end
+
   systemd_service service_name do
     after "network-online.target"
     wants "network-online.target"


### PR DESCRIPTION
This sparse clones the prometheus-exporters, while maintaining chef git resource compatibility.

Chef git resource continues as expected.

Conditionally sparse-checkout the exporters and collectors as required.