### PR TITLE
Set dnssec negative trust anchors

### DIFF
--- a/cookbooks/networking/recipes/default.rb
+++ b/cookbooks/networking/recipes/default.rb
@@ -307,6 +307,20 @@ service "systemd-resolved" do
   action [:enable, :start]
 end
 
+directory "/etc/dnssec-trust-anchors.d" do
+  owner "root"
+  group "root"
+  mode "755"
+end
+
+template "/etc/dnssec-trust-anchors.d/chef.negative" do
+  source "dnssec-trust-anchors-negative.erb"
+  owner "root"
+  group "root"
+  mode "644"
+  notifies :restart, "service[systemd-resolved]", :immediately
+end
+
 directory "/etc/systemd/resolved.conf.d" do
   owner "root"
   group "root"

--- a/cookbooks/networking/templates/default/dnssec-trust-anchors-negative.erb
+++ b/cookbooks/networking/templates/default/dnssec-trust-anchors-negative.erb
@@ -1,0 +1,4 @@
+# DO NOT EDIT - This file is being maintained by Chef
+geo.openstreetmap.org
+10.in-addr.arpa
+internal

--- a/cookbooks/networking/templates/default/dnssec-trust-anchors-negative.erb
+++ b/cookbooks/networking/templates/default/dnssec-trust-anchors-negative.erb
@@ -1,4 +1,31 @@
 # DO NOT EDIT - This file is being maintained by Chef
 geo.openstreetmap.org
 10.in-addr.arpa
+# systemd-resolved NPA defaults
+168.192.in-addr.arpa
+16.172.in-addr.arpa
+17.172.in-addr.arpa
+18.172.in-addr.arpa
+19.172.in-addr.arpa
+20.172.in-addr.arpa
+21.172.in-addr.arpa
+22.172.in-addr.arpa
+23.172.in-addr.arpa
+24.172.in-addr.arpa
+25.172.in-addr.arpa
+26.172.in-addr.arpa
+27.172.in-addr.arpa
+28.172.in-addr.arpa
+29.172.in-addr.arpa
+30.172.in-addr.arpa
+31.172.in-addr.arpa
+corp
+d.f.ip6.arpa
+home
+home.arpa
 internal
+intranet
+lan
+local
+private
+test

--- a/cookbooks/networking/templates/default/dnssec-trust-anchors-negative.erb
+++ b/cookbooks/networking/templates/default/dnssec-trust-anchors-negative.erb
@@ -1,5 +1,6 @@
 # DO NOT EDIT - This file is being maintained by Chef
 geo.openstreetmap.org
+geo.osm.org
 10.in-addr.arpa
 # systemd-resolved NPA defaults
 168.192.in-addr.arpa


### PR DESCRIPTION
Set DNSSSEC negative trust anchors.

* `geo.openstreetmap.org` because systemd-resolved in Ubuntu 22.04 seems to occasionally get confused if this zone is DNSSEC signed and resolving domains in this zone fail (eg: `nominatim.geo.openstreetamp.org`). Might be related to upstream DNS server features.
* `10.in-addr.arpa` unsigned local zone.
* `internal` used by containers.