### PR TITLE
web: add openstreetmap.com to certificate

### DIFF
--- a/cookbooks/web/recipes/rails.rb
+++ b/cookbooks/web/recipes/rails.rb
@@ -31,11 +31,11 @@ web_passwords = data_bag_item("web", "passwords")
 db_passwords = data_bag_item("db", "passwords")
 
 ssl_certificate "www.openstreetmap.org" do
-  domains ["www.openstreetmap.org", "www.osm.org",
+  domains ["www.openstreetmap.org", "www.osm.org", "www.openstreetmap.com",
            "api.openstreetmap.org", "api.osm.org",
            "maps.openstreetmap.org", "maps.osm.org",
            "mapz.openstreetmap.org", "mapz.osm.org",
-           "openstreetmap.org", "osm.org"]
+           "openstreetmap.org", "osm.org", "openstreetmap.com"]
   notifies :reload, "service[apache2]"
 end
 


### PR DESCRIPTION
`openstreetmap.COM` is a commonly used incorrect domain for us.

The domain displays an HTTPS certificate error. Some users may still have a redirect cached and will not see the error (Redirect cached until 2038)

This PR adds the certificate so that the `openstreetmap.COM` will be correctly redirected without a potential certificate issue.