### PR TITLE
ohai: use standard plugin path

### DIFF
--- a/cookbooks/ohai/resources/plugin.rb
+++ b/cookbooks/ohai/resources/plugin.rb
@@ -29,11 +29,17 @@ action :create do
     action :nothing
   end
 
-  directory "/etc/chef/ohai" do
+  directory "/etc/chef/ohai/plugins" do
     owner "root"
     group "root"
     mode "755"
     recursive true
+  end
+
+  # FIXME: Cleanup of plugins in the old location
+  declare_resource :file, plugin_old_path do
+    action :delete
+    notifies :reload, "ohai[#{new_resource.plugin}]"
   end
 
   declare_resource :template, plugin_path do
@@ -52,7 +58,11 @@ action :delete do
 end
 
 action_class do
-  def plugin_path
+  def plugin_old_path
     "/etc/chef/ohai/#{new_resource.plugin}.rb"
+  end
+
+  def plugin_path
+    "/etc/chef/ohai/plugins/#{new_resource.plugin}.rb"
   end
 end


### PR DESCRIPTION
`/etc/chef/ohai/plugins/` is the standard ohai plugin path, previously we used `/etc/chef/ohai/` and appended in that path via chef client.rb `ohai.plugin_path << "/etc/chef/ohai"`

This code changes to use the standard path and has cleanup code to remove plugins from the old path.