### PR TITLE
Add prometheus alert for too many parallel connections to nominatim

### DIFF
--- a/cookbooks/prometheus/templates/default/alert_rules.yml.erb
+++ b/cookbooks/prometheus/templates/default/alert_rules.yml.erb
@@ -488,6 +488,11 @@ groups:
           alertgroup: nominatim
         annotations:
           delay: "{{ $value | humanizeDuration }}"
+      - alert: nominatim connections
+        expr: sum(nginx_connections_writing and on (instance) chef_role{name="nominatim"}) > 2500
+        for: 15m
+        labels:
+          alertgroup: nominatim
   - name: overpass
     rules:
       - alert: overpass osm database age


### PR DESCRIPTION
My first attempt at prometheus alert rule writing. Not sure I got it right.

What I'm trying to do is to trigger an alert when the number of connections in writing in [Nominatim's 'Active Connections by State' graph](https://prometheus.openstreetmap.org/d/6qvCSGtnz/nominatim) goes over 2.5k. This intentionally works on the sum of all Nominatim servers because it'd need different limits for the different servers otherwise.