### PR TITLE
CiviCRM

### DIFF
--- a/cookbooks/civicrm/attributes/default.rb
+++ b/cookbooks/civicrm/attributes/default.rb
@@ -60,7 +60,7 @@ default[:civicrm][:extensions][:membershipextra][:revision] = "847fa370639d4ace4
 # Verify active contributor status
 default[:civicrm][:extensions][:osmfverifycontributor][:name] = "osmf-verify-contributor"
 default[:civicrm][:extensions][:osmfverifycontributor][:repository] = "https://github.com/openstreetmap/osmf-verify-contributor.git"
-default[:civicrm][:extensions][:osmfverifycontributor][:revision] = "5fb3ebf6c6636e7e4eeadd074b8074593330ddca"
+default[:civicrm][:extensions][:osmfverifycontributor][:revision] = "73e4d5cf77623cb9a6217f0b0166386f96330b6f"
 
 # Pay with Mollie
 default[:civicrm][:extensions][:omnipay][:name] = "nz.co.fuzion.omnipaymultiprocessor"

--- a/cookbooks/civicrm/attributes/default.rb
+++ b/cookbooks/civicrm/attributes/default.rb
@@ -36,9 +36,9 @@ default[:civicrm][:extensions][:civiprospect][:repository] = "https://github.com
 default[:civicrm][:extensions][:civiprospect][:revision] = "3.1.2"
 
 # advanced fundraising reports
-default[:civicrm][:extensions][:advancedfundraisingreports][:name] = "net.ourpowerbase.report.advancedfundraising"
-default[:civicrm][:extensions][:advancedfundraisingreports][:repository] = "https://github.com/jmcclelland/net.ourpowerbase.report.advancedfundraising.git"
-default[:civicrm][:extensions][:advancedfundraisingreports][:revision] = "3d5bd6cab70ba338bc85d42b4853dd4a6f8c9f9b"
+# default[:civicrm][:extensions][:advancedfundraisingreports][:name] = "net.ourpowerbase.report.advancedfundraising"
+# default[:civicrm][:extensions][:advancedfundraisingreports][:repository] = "https://github.com/jmcclelland/net.ourpowerbase.report.advancedfundraising.git"
+# default[:civicrm][:extensions][:advancedfundraisingreports][:revision] = "3d5bd6cab70ba338bc85d42b4853dd4a6f8c9f9b"
 
 # membership churn report
 default[:civicrm][:extensions][:membershipchurn][:name] = "uk.co.vedaconsulting.membershipchurnchart"

--- a/cookbooks/civicrm/recipes/default.rb
+++ b/cookbooks/civicrm/recipes/default.rb
@@ -218,8 +218,6 @@ settings = edit_file "#{civicrm_directory}/civicrm/templates/CRM/common/civicrm.
   line.gsub!(%r{// *define\('CIVICRM_CMSDIR', '/path/to/install/root/'\);}, "define('CIVICRM_CMSDIR', '/srv/supporting.openstreetmap.org');")
   # Don't recompile smarty templates on every call https://docs.civicrm.org/sysadmin/en/latest/setup/optimizations/#disable-compile-check
   line.gsub!(%r{//  define\('CIVICRM_TEMPLATE_COMPILE_CHECK', FALSE\);}, "define('CIVICRM_TEMPLATE_COMPILE_CHECK', FALSE);")
-  # Upgrade smarty 2 to smarty 4
-  line.gsub!(/if \(strpos\(CIVICRM_UF_BASEURL, 'localhost'\) !== FALSE \|\| strpos\(CIVICRM_UF_BASEURL, 'demo\.civicrm\.org'\) !== FALSE\) \{/, "if (true) {")
 
   line
 end

--- a/cookbooks/civicrm/recipes/default.rb
+++ b/cookbooks/civicrm/recipes/default.rb
@@ -235,6 +235,10 @@ file "/srv/supporting.openstreetmap.org/wp-content/uploads/civicrm/civicrm.setti
   content settings
 end
 
+file "#{civicrm_directory}/civicrm.settings.php" do
+  action :delete
+end
+
 systemd_service "osmf-crm-jobs" do
   description "Run CRM jobs"
   exec_start "/usr/bin/php #{civicrm_directory}/civicrm/bin/cli.php -s supporting.openstreetmap.org -u batch -p \"#{passwords['batch']}\" -e Job -a execute"

--- a/cookbooks/civicrm/recipes/default.rb
+++ b/cookbooks/civicrm/recipes/default.rb
@@ -224,7 +224,13 @@ settings = edit_file "#{civicrm_directory}/civicrm/templates/CRM/common/civicrm.
   line
 end
 
-file "#{civicrm_directory}/civicrm.settings.php" do
+directory "/srv/supporting.openstreetmap.org/wp-content/uploads/civicrm" do
+  owner "www-data"
+  group "www-data"
+  mode "755"
+end
+
+file "/srv/supporting.openstreetmap.org/wp-content/uploads/civicrm/civicrm.settings.php" do
   owner "wordpress"
   group "wordpress"
   mode "644"


### PR DESCRIPTION
- make changes persistent from last tricky civicrm update
- update osmf verify contributor plugin
- write civicrm config to new location, old one is deprecated since a few years

Please check the config file currently on the production server (there is one already in the new location) before running chef. If there are differences, we might need to reflect them in chef as well.