### PR TITLE
apache: only show major/minor apache version in response header

### DIFF
--- a/cookbooks/apache/templates/default/httpd.conf.erb
+++ b/cookbooks/apache/templates/default/httpd.conf.erb
@@ -6,6 +6,9 @@ Protocols h2 http/1.1
 # Set the number of seconds before receives and sends time out
 Timeout <%= node[:apache][:timeout] %>
 
+# Set only Major and Minor in the Server response header
+ServerTokens Minor
+
 # Decide whether or not to allow persistent connections
 Keepalive <%= node[:apache][:keepalive] ? "On" : "Off" %>
 <% if node[:apache][:mpm] == "prefork" -%>


### PR DESCRIPTION
Only show show `Server: Apache/2.4` instead of full `Server: Apache/2.4.54 (Ubuntu)` response header.

The full version is unnecessary level detail and may cause false positive security reports. 
