### PR TITLE
Add docker hub login to avoid hub IP limits

### DIFF
--- a/.github/workflows/test-kitchen.yml
+++ b/.github/workflows/test-kitchen.yml
@@ -169,6 +169,12 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+      if: github.repository == 'openstreetmap/chef' && github.event_name != 'pull_request'
     - name: Check out code
       uses: actions/checkout@v4
     - name: Setup ruby


### PR DESCRIPTION
Workaround anonymous limits of Docker Hub registry by having the GHA login.