### PR TITLE
Don't try to get a cert for vector.osm

### DIFF
--- a/cookbooks/vectortile/recipes/default.rb
+++ b/cookbooks/vectortile/recipes/default.rb
@@ -40,7 +40,7 @@ nginx_site "vector.openstreetmap.org" do
 end
 
 ssl_certificate node[:fqdn] do
-  domains [node[:fqdn], "vector.openstreetmap.org"]
+  domains [node[:fqdn]]
   notifies :reload, "service[nginx]"
 end
 


### PR DESCRIPTION
This domain is pointed at fastly, not the backend