### PR TITLE
Install curl as part of tools

### DIFF
--- a/cookbooks/tools/recipes/default.rb
+++ b/cookbooks/tools/recipes/default.rb
@@ -20,6 +20,7 @@
 package %w[
   bash-completion
   cron
+  curl
   dmidecode
   ethtool
   iotop


### PR DESCRIPTION
I figure curl is generally useful, and it's not part of a minimal debian install