### PR TITLE
Rely on max_connections set in attributes

### DIFF
--- a/roles/vectortile.rb
+++ b/roles/vectortile.rb
@@ -13,7 +13,6 @@ default_attributes(
   :postgresql => {
     :settings => {
       :defaults => {
-        :max_connections => "250",
         :shared_buffers => "16GB",
         :work_mem => "128MB",
         :maintenance_work_mem => "8GB",


### PR DESCRIPTION
This value scales with number of cores instead of a flat 250