### PR TITLE
tile: use osm2pgsql-replication promethus

### DIFF
--- a/cookbooks/tile/recipes/default.rb
+++ b/cookbooks/tile/recipes/default.rb
@@ -668,7 +668,19 @@ tile_directories.each do |directory|
   end
 end
 
-package "ruby-webrick"
+package %w[
+  ruby-pg
+  ruby-webrick
+]
+
+prometheus_exporter "osm2pgsql" do
+  port 10027
+  user "tileupdate"
+  restrict_address_families "AF_UNIX"
+  options [
+    "--database-name=gis"
+  ]
+end
 
 prometheus_exporter "modtile" do
   port 9494


### PR DESCRIPTION
The logic that generates the renderd age metric can be removed when there is enough data for the new metric in Prometheus.

This logic exists in the prometheus exporters package.