### PR TITLE
Use chef image clone to ghcr to workaround docker hub limits

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -21,6 +21,8 @@ provisioner:
   name: dokken
   chef_license: accept
   data_bags_path: test/data_bags
+  chef_image: ghcr.io/firefishy/chef-docker-image:latest
+  chef_version: latest
   slow_resource_report: true
   clean_dokken_sandbox: true
   attributes:


### PR DESCRIPTION
I created https://github.com/Firefishy/chef-docker-image which uses github actions to clone the official Chef docker image and push it to GHCR.

This is to avoid the extremely low docker hub download limits which are breaking our tests.