### PR TITLE
vectortile: Set saner thread numbers

### DIFF
--- a/cookbooks/vectortile/attributes/default.rb
+++ b/cookbooks/vectortile/attributes/default.rb
@@ -1,16 +1,16 @@
 default[:vectortile][:database][:cluster] = "16/main"
 default[:vectortile][:database][:postgis] = "3"
 default[:vectortile][:database][:nodes_store] = :flat
-default[:vectortile][:serve][:threads] = node.cpu_cores
+default[:vectortile][:serve][:threads] = (node.cpu_cores * 0.5).ceil
 default[:vectortile][:serve][:mode] = :live
 default[:vectortile][:replication][:url] = "https://osm-planet-eu-central-1.s3.dualstack.eu-central-1.amazonaws.com/planet/replication/minute"
 default[:vectortile][:replication][:status] = :enabled
 default[:vectortile][:replication][:tileupdate] = :enabled
-default[:vectortile][:replication][:threads] = node.cpu_cores
+default[:vectortile][:replication][:threads] = (node.cpu_cores * 0.5).ceil
 
 default[:postgresql][:versions] |= [node[:vectortile][:database][:cluster].split("/").first]
 default[:postgresql][:monitor_database] = "tiles"
 # As an absolute worst case, the server might have the serving, update, and a manual generation process going on.
-default[:postgresql][:settings][:defaults][:max_connections] = (node.cpu_cores * 6 + 20).to_s
+default[:postgresql][:settings][:defaults][:max_connections] = (node[:vectortile][:serve][:threads] * 2 + node[:vectortile][:replication][:threads] * 2 + node.cpu_cores * 2 + 20).to_s
 default[:accounts][:users][:tileupdate][:status] = :role
 default[:accounts][:users][:tilekiln][:status] = :role

--- a/cookbooks/vectortile/recipes/default.rb
+++ b/cookbooks/vectortile/recipes/default.rb
@@ -258,7 +258,7 @@ template "/usr/local/bin/tiles-rerender" do
   owner "root"
   group "root"
   mode "755"
-  variables :tilekiln_bin => "#{tilekiln_directory}/bin/tilekiln", :source_database => "spirit", :storage_database => "tiles", :config_path => "#{shortbread_config}", :tiles_file => "/srv/vector.openstreetmap.org/data/tiles.txt", :update_threads => 4
+  variables :tilekiln_bin => "#{tilekiln_directory}/bin/tilekiln", :source_database => "spirit", :storage_database => "tiles", :config_path => "#{shortbread_config}", :tiles_file => "/srv/vector.openstreetmap.org/data/tiles.txt"
 end
 
 systemd_service "replicate" do


### PR DESCRIPTION
The parallelism of tile rendering was incorrectly set to 4. This sets it to a saner limit, as well as limits the CPUs used by serving.