### PR TITLE
vectortile: Use flex expiry

### DIFF
--- a/cookbooks/vectortile/recipes/default.rb
+++ b/cookbooks/vectortile/recipes/default.rb
@@ -250,7 +250,7 @@ template "/usr/local/bin/vector-update" do
   owner "root"
   group "root"
   mode "755"
-  variables :tilekiln_bin => "#{tilekiln_directory}/bin/tilekiln", :source_database => "spirit", :config_path => "#{shortbread_config}", :diff_size => "1000", :tiles_file => "/srv/vector.openstreetmap.org/data/tiles.txt", :post_processing => "/usr/local/bin/tiles-rerender"
+  variables :tilekiln_bin => "#{tilekiln_directory}/bin/tilekiln", :source_database => "spirit", :config_path => "#{shortbread_config}", :diff_size => "1000", :expiry_dir => "/srv/vector.openstreetmap.org/data/", :post_processing => "/usr/local/bin/tiles-rerender"
 end
 
 template "/usr/local/bin/tiles-rerender" do
@@ -258,7 +258,7 @@ template "/usr/local/bin/tiles-rerender" do
   owner "root"
   group "root"
   mode "755"
-  variables :tilekiln_bin => "#{tilekiln_directory}/bin/tilekiln", :source_database => "spirit", :storage_database => "tiles", :config_path => "#{shortbread_config}", :tiles_file => "/srv/vector.openstreetmap.org/data/tiles.txt", :update_threads => 4
+  variables :tilekiln_bin => "#{tilekiln_directory}/bin/tilekiln", :source_database => "spirit", :storage_database => "tiles", :config_path => "#{shortbread_config}", :expiry_dir => "/srv/vector.openstreetmap.org/data/", :update_threads => 4
 end
 
 systemd_service "replicate" do

--- a/cookbooks/vectortile/templates/default/import-planet.erb
+++ b/cookbooks/vectortile/templates/default/import-planet.erb
@@ -7,7 +7,7 @@
 
 set -e
 
-export LUA_PATH='/srv/vector.openstreetmap.org/osm2pgsql-themepark/lua/?.lua;/srv/vector.openstreetmap.org/spirit/?.lua;;'
+export LUA_PATH='/srv/vector.openstreetmap.org/osm2pgsql-themepark/lua/?.lua;;'
 
 # Import the osm2pgsql file specified as an argument, using the locations for spirit
 osm2pgsql \

--- a/cookbooks/vectortile/templates/default/tiles-rerender.erb
+++ b/cookbooks/vectortile/templates/default/tiles-rerender.erb
@@ -1,7 +1,11 @@
 #!/bin/sh
 set -eu
-<%= @tilekiln_bin %> generate tiles \
+
+cd "<%= @expiry_dir %>"
+
+wc -l z*.txt
+cat z*.txt | <%= @tilekiln_bin %> generate tiles \
 --source-dbname "<%= @source_database %>" \
 --storage-dbname "<%= @storage_database %>" \
 --num-threads "<%= node[:vectortile][:replication][:threads] %>" \
---config <%= @config_path %> < <%= @tiles_file %>
+--config <%= @config_path %>

--- a/cookbooks/vectortile/templates/default/vector-update-notile.erb
+++ b/cookbooks/vectortile/templates/default/vector-update-notile.erb
@@ -1,12 +1,13 @@
 #!/bin/sh
 
 # Usage
-# sudo -u tilekiln vector-update
+# sudo -u tileupdate vector-update
 
 set -eu
 
-export LUA_PATH='/srv/vector.openstreetmap.org/osm2pgsql-themepark/lua/?.lua;/srv/vector.openstreetmap.org/spirit/?.lua;;'
+export LUA_PATH='/srv/vector.openstreetmap.org/osm2pgsql-themepark/lua/?.lua;;'
 
+cd "<%= @expiry_dir %>"
 osm2pgsql-replication update \
   -d "<%= @source_database %>" \
   --max-diff-size "<%= @diff_size %>"

--- a/cookbooks/vectortile/templates/default/vector-update-tile.erb
+++ b/cookbooks/vectortile/templates/default/vector-update-tile.erb
@@ -5,11 +5,10 @@
 
 set -eu
 
-export LUA_PATH='/srv/vector.openstreetmap.org/osm2pgsql-themepark/lua/?.lua;/srv/vector.openstreetmap.org/spirit/?.lua;;'
+export LUA_PATH='/srv/vector.openstreetmap.org/osm2pgsql-themepark/lua/?.lua;;'
 
+cd "<%= @expiry_dir %>"
 osm2pgsql-replication update \
   -d "<%= @source_database %>" \
   --max-diff-size "<%= @diff_size %>" \
-  --post-processing "<%= @post_processing %>" \
-  -- --expire-tiles=10-14 \
-  --expire-output="<%= @tiles_file %>"
+  --post-processing "<%= @post_processing %>"


### PR DESCRIPTION
This uses the new flex expiry code in spirit/shortbread to reduce the number of tiles that need to be re-rendered each update.