### PR TITLE
Update YAML.safe_load arguments in replicate-changesets

### DIFF
--- a/cookbooks/planet/files/default/replication-bin/replicate-changesets
+++ b/cookbooks/planet/files/default/replication-bin/replicate-changesets
@@ -139,7 +139,7 @@ end
 class Replicator
   def initialize(config)
     @config = YAML.safe_load(File.read(config))
-    @state = YAML.safe_load(File.read(@config["state_file"]), [Time])
+    @state = YAML.safe_load(File.read(@config["state_file"]), :permitted_classes => [Time])
     @conn = PG::Connection.connect(@config["db"])
     # get current time from the database rather than the current system
     @now = @conn.exec("select now() as now").map { |row| Time.parse(row["now"]) }[0]


### PR DESCRIPTION
I wanted to check how replicate-changesets works with https://github.com/openstreetmap/openstreetmap-website/pull/5309 and it didn't run for a number of reasons. First, `YAML.safe_load` arguments are outdated since https://github.com/ruby/psych/commit/0767227051dbddf1f949eef512c174deabf22891 and an update like https://github.com/openstreetmap/chef/commit/8061c292a2490f50f1e84a5bccde1b45e5d3d511 is needed.