### PR TITLE
Use empty hash fallback when loading state file in replicate-changesets

### DIFF
--- a/cookbooks/planet/files/default/replication-bin/replicate-changesets
+++ b/cookbooks/planet/files/default/replication-bin/replicate-changesets
@@ -139,7 +139,7 @@ end
 class Replicator
   def initialize(config)
     @config = YAML.safe_load(File.read(config))
-    @state = YAML.safe_load(File.read(@config["state_file"]), :permitted_classes => [Time])
+    @state = YAML.safe_load(File.read(@config["state_file"]), :permitted_classes => [Time], :fallback => {})
     @conn = PG::Connection.connect(@config["db"])
     # get current time from the database rather than the current system
     @now = @conn.exec("select now() as now").map { |row| Time.parse(row["now"]) }[0]


### PR DESCRIPTION
If I use readme at https://github.com/zerebubuth/openstreetmap-changeset-replication as a guide, it says "a state file, which can be empty the first time it's used". But that's not going to work because an empty file is read as `nil`, then the code tries to access elements of that `nil` and crashes.

Here I change an empty state_file to be read as an empty hash.