### PR TITLE
Terminate fdirsync loop when "." is reached in replicate-changesets

### DIFF
--- a/cookbooks/planet/files/default/replication-bin/replicate-changesets
+++ b/cookbooks/planet/files/default/replication-bin/replicate-changesets
@@ -127,7 +127,7 @@ end
 # sync a directory to guarantee it's on disk. have to recurse to the root
 # to guarantee sync for newly created directories.
 def fdirsync(d)
-  while d != "/"
+  while d != "/" && d != "."
     fsync(d)
     d = File.dirname(d)
   end


### PR DESCRIPTION
Looking at the readme in https://github.com/zerebubuth/openstreetmap-changeset-replication you can see this line in the example config:

```
data_dir: replication/
```

Looks like you can specify a relative path as `data_dir`. But actually you can't, because the loop I modify in this PR will never terminate. The server config avoids this issue by using an absolute path:

https://github.com/openstreetmap/chef/blob/e4330da209a809e67d03ff9e2b0a7f4bcac55863/cookbooks/planet/templates/default/changesets.conf.erb#L3