### PR TITLE
fix: README.md grammar punctuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 This repository manages the configuration of all the servers run by the
 OpenStreetMap Foundation's Operations Working Group. We use
-[Chef](https://www.chef.io/) to automated the configuration of all of our
+[Chef](https://www.chef.io/) to automate the configuration of all of our
 servers.
 
 [OSMF Operations Working Group](https://operations.osmfoundation.org/)
@@ -14,20 +14,20 @@ servers.
 
 We make extensive use of roles to configure the servers. In general we have:
 
-## Server-specific roles (e.g. [faffy.rb](roles/faffy.rb))
+## Server-specific roles (e.g., [faffy.rb](roles/faffy.rb))
 
 These deal with particular setup or quirks of a server, such as its IP address. They also include roles representing the service they are performing, and the location they are in and any particular hardware they have that needs configuration.
 All our servers are [named after dragons](https://wiki.openstreetmap.org/wiki/Servers/Name_Ideas).
 
-## Hardware-specific roles (e.g. [hp-g9.rb](roles/hp-g9.rb))
+## Hardware-specific roles (e.g., [hp-g9.rb](roles/hp-g9.rb))
 
 Covers anything specific to a certain piece of hardware, like a motherboard, that could apply to multiple machines.
 
-## Location-specific roles (e.g. [equinix-dub.rb](roles/equinix-dub.rb))
+## Location-specific roles (e.g., [equinix-dub.rb](roles/equinix-dub.rb))
 
 These form a hierarchy of datacentres, organisations, and countries where our servers are located.
 
-## Service-specific roles (e.g. [web-frontend](roles/web-frontend.rb))
+## Service-specific roles (e.g., [web-frontend](roles/web-frontend.rb))
 
 These cover the services that the server is running, and will include the recipes required for that service along with any specific configurations and other cascading roles.
 


### PR DESCRIPTION
- to automate the configuration...
- e.g.,  

see:
https://www.merriam-webster.com/dictionary/e.g.#examples