### PR TITLE
add au_act_aerial mapserver imagery

### DIFF
--- a/cookbooks/imagery/recipes/au_act_aerial.rb
+++ b/cookbooks/imagery/recipes/au_act_aerial.rb
@@ -1,0 +1,67 @@
+#
+# Cookbook:: imagery
+# Recipe:: au_act_aerial
+#
+# Copyright:: 2025, OpenStreetMap Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe "imagery"
+
+imagery_site "act-imagery.openstreetmap.org" do
+  title "OpenStreetMap - ACT Imagery"
+  aliases ["act-imagery.osm.org"]
+  # https://leafletjs.com/reference.html#latlngbounds format
+  # [[south, west], [north, east]]
+  bbox [[-35.942, 148.729], [-35.117, 149.430]]
+end
+
+imagery_layer "act_aerial_imagery_202409" do
+  site "act-imagery.openstreetmap.org"
+  title "ACT Aerial Imagery 202409"
+  projection "EPSG:7855"
+  source "https://tiles.arcgis.com/tiles/E5n4f1VY84i0xSjy/arcgis/rest/services/ACT_Aerial_Imagery_202409/MapServer/WMTS/1.0.0/WMTSCapabilities.xml"
+  # attribution per https://www.actmapi.act.gov.au/terms-and-conditions and https://tiles.arcgis.com/tiles/E5n4f1VY84i0xSjy/arcgis/rest/services/ACT_Aerial_Imagery_202409/MapServer/
+  copyright "ACT Imagery from <a href='https://www.actmapi.act.gov.au/home'>ACTmapi</a> ©Australian Capital Territory and MetroMap."
+  default_layer true
+  background_colour "0 0 0"
+  extension "jpeg"
+  max_zoom 22
+end
+
+imagery_layer "act_aerial_imagery_202311" do
+  site "act-imagery.openstreetmap.org"
+  title "ACT Aerial Imagery 202311"
+  projection "EPSG:7855"
+  source "https://tiles.arcgis.com/tiles/E5n4f1VY84i0xSjy/arcgis/rest/services/ACT_Aerial_Imagery_202311/MapServer/WMTS/1.0.0/WMTSCapabilities.xml"
+  # attribution per https://www.actmapi.act.gov.au/terms-and-conditions and https://tiles.arcgis.com/tiles/E5n4f1VY84i0xSjy/arcgis/rest/services/ACT_Aerial_Imagery_202311/MapServer/
+  copyright "ACT Imagery from <a href='https://www.actmapi.act.gov.au/home'>ACTmapi</a> ©Australian Capital Territory and MetroMap."
+  default_layer true
+  background_colour "0 0 0"
+  extension "jpeg"
+  max_zoom 22
+end
+
+imagery_layer "act_aerial_imagery_202305" do
+  site "act-imagery.openstreetmap.org"
+  title "ACT Aerial Imagery 202305"
+  projection "EPSG:7855"
+  source "https://tiles.arcgis.com/tiles/E5n4f1VY84i0xSjy/arcgis/rest/services/ACT_Aerial_Imagery_202305/MapServer/WMTS/1.0.0/WMTSCapabilities.xml"
+  # attribution per https://www.actmapi.act.gov.au/terms-and-conditions and https://tiles.arcgis.com/tiles/E5n4f1VY84i0xSjy/arcgis/rest/services/ACT_Aerial_Imagery_202305/MapServer/
+  copyright "ACT Imagery from <a href='https://www.actmapi.act.gov.au/home'>ACTmapi</a> ©Australian Capital Territory and MetroMap."
+  default_layer true
+  background_colour "0 0 0"
+  extension "jpeg"
+  max_zoom 22
+end

--- a/roles/imagery.rb
+++ b/roles/imagery.rb
@@ -35,6 +35,7 @@ default_attributes(
 
 run_list(
   "recipe[imagery::au_agri]",
+  "recipe[imagery::au_act_aerial]",
   "recipe[imagery::gb_ea]",
   "recipe[imagery::gb_hampshire_aerial]",
   "recipe[imagery::gb_os_sv]",


### PR DESCRIPTION
We have [permission to use](https://wiki.openstreetmap.org/wiki/File:ACT_Government_20180314_Permission_to_Incorporate_CCBY_data_into_OSM.PDF) ACT CC BY imagery in OSM and have a [few layers in the ELI](https://github.com/osmlab/editor-layer-index/tree/gh-pages/sources/oceania/au/act), however recently these have only been published as WMTS with EPSG:7855.

This works in JOSM, but unfortunately WMTS won't (unlike WMS) accept a request to serve images in Web Mercator and iD doesn't support reprojecting image tiles from EPSG:7855 to WebMercator.

However since you're running a MapServer service already, perhaps we can include the configuration needed to proxy these layers from EPSG:7855 tiles to Web Mercator tiles?

I've tested a version of this mapserver .map file locally and it seems to be working, but I haven't tested the cookbooks (sorry no experience with that).

cc @Firefishy 