### PR TITLE
Allow podman to run kitchen tests

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -62,6 +62,18 @@ platforms:
         - RUN /usr/bin/apt-get install -y eatmydata
         - RUN echo /usr/lib/$(uname -m)-linux-gnu/libeatmydata.so >>/etc/ld.so.preload
 
+# When using podman we have to manually start chef to workaround a volume issue
+lifecycle:
+  pre_create: |
+    if command -v podman >/dev/null 2>&1; then
+      podman create --name chef-latest --replace docker.io/chef/chef:latest sh
+      podman start chef-latest
+    fi
+  post_destroy: |
+    if command -v podman >/dev/null 2>&1; then
+      podman container rm -iv chef-latest
+    fi
+
 suites:
   - name: accounts
     run_list:


### PR DESCRIPTION
Due to differences in how podman and docker treat volumes, we have to hack in a workaround for podman to start the chef container up before it runs a suite.  Otherwise you get a failure to find the chef-client binary

https://github.com/test-kitchen/kitchen-dokken/issues/255 has more information on the cause