### PR TITLE
Pass only HEAD and GET /api/0.6/(elements) requests to cgimap

### DIFF
--- a/cookbooks/dev/templates/default/apache.rails.erb
+++ b/cookbooks/dev/templates/default/apache.rails.erb
@@ -48,6 +48,7 @@
         RewriteRule ^/api/0\.6/(node|way|relation)/[0-9]+/relations(\.json|\.xml)?$ unix:<%= @cgimap_socket %>|fcgi://127.0.0.1$0 [P]
         RewriteRule ^/api/0\.6/node/[0-9]+/ways(\.json|\.xml)?$ unix:<%= @cgimap_socket %>|fcgi://127.0.0.1$0 [P]
         RewriteRule ^/api/0\.6/(way|relation)/[0-9]+/full(\.json|\.xml)?$ unix:<%= @cgimap_socket %>|fcgi://127.0.0.1$0 [P]
+        RewriteCond %{REQUEST_METHOD} ^(HEAD|GET)$
         RewriteRule ^/api/0\.6/(nodes|ways|relations)(\.json|\.xml)?$ unix:<%= @cgimap_socket %>|fcgi://127.0.0.1$0 [P]
         RewriteRule ^/api/0\.6/changeset/[0-9]+/(upload|download)(\.json|\.xml)?$ unix:<%= @cgimap_socket %>|fcgi://127.0.0.1$0 [P]
 <% end -%>

--- a/cookbooks/web/templates/default/apache.frontend.erb
+++ b/cookbooks/web/templates/default/apache.frontend.erb
@@ -186,6 +186,7 @@ ErrorLog /var/log/apache2/error.log
   RewriteRule ^/api/0\.6/(node|way|relation)/[0-9]+/relations(\.json|\.xml)?$ unix:/run/cgimap/socket|fcgi://127.0.0.1$0 [P]
   RewriteRule ^/api/0\.6/node/[0-9]+/ways(\.json|\.xml)?$ unix:/run/cgimap/socket|fcgi://127.0.0.1$0 [P]
   RewriteRule ^/api/0\.6/(way|relation)/[0-9]+/full(\.json|\.xml)?$ unix:/run/cgimap/socket|fcgi://127.0.0.1$0 [P]
+  RewriteCond %{REQUEST_METHOD} ^(HEAD|GET)$
   RewriteRule ^/api/0\.6/(nodes|ways|relations)(\.json|\.xml)?$ unix:/run/cgimap/socket|fcgi://127.0.0.1$0 [P]
   RewriteRule ^/api/0\.6/changeset/[0-9]+/(upload|download)(\.json|\.xml)?$ unix:/run/cgimap/socket|fcgi://127.0.0.1$0 [P]
 


### PR DESCRIPTION
In https://github.com/openstreetmap/openstreetmap-website/pull/5591 I added a standard `create` action for elements to OSM API. It's performed by POSTs at element index routes:
- `/api/0.6/nodes`
- `/api/0.6/ways`
- `/api/0.6/relations`

However those are still mapped to cgimap on the servers, even though cgimap doesn't support POST requests at these paths. cgimap doesn't have any functionality for single-element writes and there are no plans to add it, only changeset uploads are supported for writing map data.