### PR TITLE
web: Ignore GoogleAssociationService assetlinks.json requests

### DIFF
--- a/cookbooks/web/templates/default/apache.frontend.erb
+++ b/cookbooks/web/templates/default/apache.frontend.erb
@@ -2,7 +2,7 @@
 
 #
 # Setup logging
-# 
+#
 SetEnvIfNoCase Authorization "^Basic " AUTH_METHOD=basic
 SetEnvIfNoCase Authorization "^OAuth " AUTH_METHOD=oauth1
 SetEnvIfNoCase Authorization "^Bearer " AUTH_METHOD=oauth2
@@ -107,6 +107,13 @@ ErrorLog /var/log/apache2/error.log
   #
   RewriteCond "%{QUERY_STRING}" "^q=abcde&t=20"
   RewriteRule "^/api/0\.6/notes/search$" - [R=429,L]
+
+  #
+  # Ignore GoogleAssociationService request storm
+  # https://en.osm.town/@osm_tech/114205363076771822
+  #
+  RewriteCond %{HTTP_USER_AGENT} "GoogleAssociationService"
+  RewriteRule "^/\.well-known/assetlinks\.json$" - [R=429,L]
 
   #
   # Force special MIME type for crossdomain.xml files


### PR DESCRIPTION
`GoogleAssociationService` sends around 1,000,000 requests per day to `/.well-known/assetlinks.json`, we respond fairly quickly with 404 via rails.

This PR hotwires the requests to instead have apache response directly with an HTTP "429 - Too Many Requests" error.