### PR TITLE
vectortile: Make the spirit and themepark versions attributes

### DIFF
--- a/cookbooks/vectortile/attributes/default.rb
+++ b/cookbooks/vectortile/attributes/default.rb
@@ -9,6 +9,8 @@ default[:vectortile][:replication][:tileupdate] = true
 default[:vectortile][:replication][:threads] = node.cpu_cores
 
 default[:vectortile][:tilekiln][:version] = "0.7.1"
+default[:vectortile][:spirit][:version] = "7fc3c62771d371f00a62249174d4d695d8324443"
+default[:vectortile][:themepark][:version] = "beb454cc56e88533fb398ab293489c4e91f4d42b"
 
 default[:postgresql][:versions] |= [node[:vectortile][:database][:cluster].split("/").first]
 default[:postgresql][:monitor_database] = "tiles"

--- a/cookbooks/vectortile/recipes/default.rb
+++ b/cookbooks/vectortile/recipes/default.rb
@@ -77,6 +77,7 @@ package %w[
 style_directory = "/srv/vector.openstreetmap.org/spirit"
 git style_directory do
   repository "https://github.com/pnorman/spirit.git"
+  revision node[:vectortile][:spirit][:version]
   user "tileupdate"
   group "tileupdate"
 end
@@ -86,7 +87,7 @@ shortbread_config = "#{style_directory}/shortbread.yaml"
 themepark_directory = "/srv/vector.openstreetmap.org/osm2pgsql-themepark"
 git themepark_directory do
   repository "https://github.com/osm2pgsql-dev/osm2pgsql-themepark.git"
-  revision "444bfbda82dea2899e77ac7f0e88ddf7f62c3b45"
+  revision node[:vectortile][:themepark][:version]
   user "tileupdate"
   group "tileupdate"
 end


### PR DESCRIPTION
This allows upgrading servers one-by-one in cases where a reload is needed.