### PR TITLE
Set PGAPPNAME for cgimap

### DIFF
--- a/cookbooks/web/recipes/cgimap.rb
+++ b/cookbooks/web/recipes/cgimap.rb
@@ -53,7 +53,8 @@ cgimap_options = {
   "CGIMAP_MAX_WAY_NODES" => node[:web][:max_number_of_way_nodes],
   "CGIMAP_MAX_RELATION_MEMBERS" => node[:web][:max_number_of_relation_members],
   "CGIMAP_RATELIMIT_UPLOAD" => "true",
-  "CGIMAP_BBOX_SIZE_LIMIT_UPLOAD" => "true"
+  "CGIMAP_BBOX_SIZE_LIMIT_UPLOAD" => "true",
+  "PGAPPNAME" => "cgimap"
 }
 
 if %w[database_readonly api_readonly].include?(node[:web][:status])


### PR DESCRIPTION
In https://en.osm.town/@pnorman/114572540276425975 , @pnorman has recommended  to set the PostgreSQL application_name.

Setting PGAPPNAME as environment variable should achieve this goal without any code changes (confirmed in local test with openstreetmap-cgimap binary) . The change in this PR is based on my understanding how cgimap.rb works. I haven't tested if the ruby script as such.

Maybe this is useful for prometheus to break down the number of connections by client application.