### PR TITLE
Switch backups to using zstd

### DIFF
--- a/cookbooks/blog/templates/default/backup-staging.cron.erb
+++ b/cookbooks/blog/templates/default/backup-staging.cron.erb
@@ -2,20 +2,21 @@
 
 # DO NOT EDIT - This file is being maintained by Chef
 
+export ZSTD_CLEVEL=11
+export ZSTD_NBTHREADS=0
+
 T=$(mktemp -d -t -p /var/tmp osm-blog-staging.XXXXXXXXXX)
 D=$(date +%Y-%m-%d)
-B=osm-blog-staging-$D.tar.gz
+B="osm-blog-staging-$D.tar.zst"
 
-mkdir $T/osm-blog-staging-$D
-echo '[mysqldump]' > $T/mysqldump.opts
-echo 'user=osm-blog-staging-user' >> $T/mysqldump.opts
-echo 'password=<%= @passwords["osm-blog-staging-user"] %>' >> $T/mysqldump.opts
-mysqldump --defaults-file=$T/mysqldump.opts --opt --no-tablespaces osm-blog-staging > $T/osm-blog-staging-$D/osm-blog-staging.sql
-ln -s /srv/staging.blog.openstreetmap.org $T/osm-blog-staging-$D/www
+mkdir "$T/osm-blog-staging-$D"
+echo '[mysqldump]' > "$T/mysqldump.opts"
+echo 'user=osm-blog-staging-user' >> "$T/mysqldump.opts"
+echo 'password=<%= @passwords["osm-blog-staging-user"] %>' >> "$T/mysqldump.opts"
+mysqldump --defaults-file="$T/mysqldump.opts" --opt --no-tablespaces osm-blog-staging > "$T/osm-blog-staging-$D/osm-blog-staging.sql"
+ln -s /srv/staging.blog.openstreetmap.org "$T/osm-blog-staging-$D/www"
 
-export RSYNC_RSH="ssh -ax"
+nice tar --create --dereference --directory="$T" --warning=no-file-changed "osm-blog-staging-$D" | nice zstd --rsyncable -o "$T/$B"
+nice rsync --preallocate --fuzzy "$T/$B" backup.openstreetmap.org::backup
 
-nice tar --create --dereference --directory=$T --warning=no-file-changed osm-blog-staging-$D | nice gzip --rsyncable -9 > $T/$B
-nice rsync --preallocate --fuzzy $T/$B backup.openstreetmap.org::backup
-
-rm -rf $T
+rm -rf "$T"

--- a/cookbooks/blog/templates/default/backup.cron.erb
+++ b/cookbooks/blog/templates/default/backup.cron.erb
@@ -2,20 +2,21 @@
 
 # DO NOT EDIT - This file is being maintained by Chef
 
+export ZSTD_CLEVEL=11
+export ZSTD_NBTHREADS=0
+
 T=$(mktemp -d -t -p /var/tmp osm-blog.XXXXXXXXXX)
 D=$(date +%Y-%m-%d)
-B=osm-blog-$D.tar.gz
+B="osm-blog-$D.tar.zst"
 
-mkdir $T/osm-blog-$D
-echo '[mysqldump]' > $T/mysqldump.opts
-echo 'user=osm-blog-user' >> $T/mysqldump.opts
-echo 'password=<%= @passwords["osm-blog-user"] %>' >> $T/mysqldump.opts
-mysqldump --defaults-file=$T/mysqldump.opts --opt --no-tablespaces osm-blog > $T/osm-blog-$D/osm-blog.sql
-ln -s /srv/blog.openstreetmap.org $T/osm-blog-$D/www
+mkdir "$T/osm-blog-$D"
+echo '[mysqldump]' > "$T/mysqldump.opts"
+echo 'user=osm-blog-user' >> "$T/mysqldump.opts"
+echo 'password=<%= @passwords["osm-blog-user"] %>' >> "$T/mysqldump.opts"
+mysqldump --defaults-file="$T/mysqldump.opts" --opt --no-tablespaces osm-blog > "$T/osm-blog-$D/osm-blog.sql"
+ln -s /srv/blog.openstreetmap.org "$T/osm-blog-$D/www"
 
-export RSYNC_RSH="ssh -ax"
+nice tar --create --dereference --directory="$T" --warning=no-file-changed "osm-blog-$D" | nice zstd --rsyncable -o "$T/$B"
+nice rsync --preallocate --fuzzy "$T/$B" backup.openstreetmap.org::backup
 
-nice tar --create --dereference --directory=$T --warning=no-file-changed osm-blog-$D | nice gzip --rsyncable -9 > $T/$B
-nice rsync --preallocate --fuzzy $T/$B backup.openstreetmap.org::backup
-
-rm -rf $T
+rm -rf "$T"

--- a/cookbooks/blogs/templates/default/backup.cron.erb
+++ b/cookbooks/blogs/templates/default/backup.cron.erb
@@ -2,16 +2,17 @@
 
 # DO NOT EDIT - This file is being maintained by Chef
 
+export ZSTD_CLEVEL=11
+export ZSTD_NBTHREADS=0
+
 T=$(mktemp -d -t -p /var/tmp blogs.XXXXXXXXXX)
 D=$(date +%Y-%m-%d)
-B=blogs-$D.tar.gz
+B="blogs-$D.tar.zst"
 
-mkdir $T/blogs-$D
+mkdir "$T/blogs-$D"
 sqlite3 /srv/blogs.openstreetmap.org/planet.db ".backup $T/blogs-$D/planet.db"
 
-export RSYNC_RSH="ssh -ax"
+nice tar --create --dereference --directory="$T" "blogs-$D" | nice zstd --rsyncable -o "$T/$B"
+nice rsync --preallocate --fuzzy "$T/$B" backup.openstreetmap.org::backup
 
-nice tar --create --dereference --directory=$T blogs-$D | nice gzip --rsyncable -9 > $T/$B
-nice rsync --preallocate --fuzzy $T/$B backup.openstreetmap.org::backup
-
-rm -rf $T
+rm -rf "$T"

--- a/cookbooks/chef/templates/default/server-backup.cron.erb
+++ b/cookbooks/chef/templates/default/server-backup.cron.erb
@@ -1,16 +1,21 @@
 #!/bin/sh
 
+# DO NOT EDIT - This file is being maintained by Chef
+
+export ZSTD_CLEVEL=11
+export ZSTD_NBTHREADS=0
+
 T=$(mktemp -d -t -p /var/tmp chef-server.XXXXXXXXXX)
 D=$(date +%Y-%m-%d)
-B=chef-server-$D.tar.gz
+B="chef-server-$D.tar.zst"
 
-mkdir $T/chef-server-$D
-chgrp opscode-pgsql $T $T/chef-server-$D
-chmod g+rwx $T $T/chef-server-$D
-sudo -u opscode-pgsql /opt/opscode/embedded/bin/pg_dumpall --file=$T/chef-server-$D/chef.dmp --clean
-ln -s /var/opt/opscode/bookshelf/data $T/chef-server-$D/bookshelf
+mkdir "$T/chef-server-$D"
+chgrp opscode-pgsql "$T" "$T/chef-server-$D"
+chmod g+rwx "$T" "$T/chef-server-$D"
+sudo -u opscode-pgsql /opt/opscode/embedded/bin/pg_dumpall --file="$T/chef-server-$D/chef.dmp" --clean
+ln -s /var/opt/opscode/bookshelf/data "$T/chef-server-$D/bookshelf"
 
-nice tar --create --dereference --directory=$T chef-server-$D | nice gzip --rsyncable -9 > $T/$B
-nice rsync --preallocate --fuzzy $T/$B backup.openstreetmap.org::backup
+nice tar --create --dereference --directory="$T" "chef-server-$D" | nice zstd --rsyncable -o "$T/$B"
+nice rsync --preallocate --fuzzy "$T/$B" backup.openstreetmap.org::backup
 
-rm -rf $T
+rm -rf "$T"

--- a/cookbooks/civicrm/templates/default/backup.cron.erb
+++ b/cookbooks/civicrm/templates/default/backup.cron.erb
@@ -2,20 +2,21 @@
 
 # DO NOT EDIT - This file is being maintained by Chef
 
+export ZSTD_CLEVEL=11
+export ZSTD_NBTHREADS=0
+
 T=$(mktemp -d -t -p /var/tmp osmf-crm.XXXXXXXXXX)
 D=$(date +%Y-%m-%d)
-B=osmf-crm-$D.tar.gz
+B="osmf-crm-$D.tar.zst"
 
-mkdir $T/osmf-crm-$D
-echo '[mysqldump]' > $T/mysqldump.opts
-echo 'user=civicrm' >> $T/mysqldump.opts
-echo 'password=<%= @passwords["database"] %>' >> $T/mysqldump.opts
-mysqldump --defaults-file=$T/mysqldump.opts --opt --skip-lock-tables --no-tablespaces civicrm > $T/osmf-crm-$D/civicrm.sql
-ln -s /srv/supporting.openstreetmap.org $T/osmf-crm-$D/www
+mkdir "$T/osmf-crm-$D"
+echo '[mysqldump]' > "$T/mysqldump.opts"
+echo 'user=civicrm' >> "$T/mysqldump.opts"
+echo 'password=<%= @passwords["database"] %>' >> "$T/mysqldump.opts"
+mysqldump --defaults-file="$T/mysqldump.opts" --opt --skip-lock-tables --no-tablespaces civicrm > "$T/osmf-crm-$D/civicrm.sql"
+ln -s /srv/supporting.openstreetmap.org "$T/osmf-crm-$D/www"
 
-export RSYNC_RSH="ssh -ax"
+nice tar --create --dereference --directory="$T" "osmf-crm-$D" | nice zstd --rsyncable -o "$T/$B"
+nice rsync --preallocate --fuzzy "$T/$B" backup.openstreetmap.org::backup
 
-nice tar --create --dereference --directory=$T osmf-crm-$D | nice gzip --rsyncable -9 > $T/$B
-nice rsync --preallocate --fuzzy $T/$B backup.openstreetmap.org::backup
-
-rm -rf $T
+rm -rf "$T"

--- a/cookbooks/community/templates/default/backup.cron.erb
+++ b/cookbooks/community/templates/default/backup.cron.erb
@@ -2,19 +2,20 @@
 
 # DO NOT EDIT - This file is being maintained by Chef
 
+export ZSTD_CLEVEL=11
+export ZSTD_NBTHREADS=0
+
 T=$(mktemp -d -t -p /var/tmp community.XXXXXXXXXX)
 D=$(date +%Y-%m-%d)
-B=community-$D.tar.gz
+B="community-$D.tar.zst"
 
-mkdir $T/community-$D
-ln -s /srv/community.openstreetmap.org/docker/containers $T/community-$D/containers
-ln -s /srv/community.openstreetmap.org/shared/web-only $T/community-$D/shared-web-only
-ln -s /srv/community.openstreetmap.org/shared/data/redis_data $T/community-$D/shared-data-redis_data
-ln -s /srv/community.openstreetmap.org/shared/data/postgres_backup $T/community-$D/shared-data-postgres_backup
+mkdir "$T/community-$D"
+ln -s /srv/community.openstreetmap.org/docker/containers "$T/community-$D/containers"
+ln -s /srv/community.openstreetmap.org/shared/web-only "$T/community-$D/shared-web-only"
+ln -s /srv/community.openstreetmap.org/shared/data/redis_data "$T/community-$D/shared-data-redis_data"
+ln -s /srv/community.openstreetmap.org/shared/data/postgres_backup "$T/community-$D/shared-data-postgres_backup"
 
-export RSYNC_RSH="ssh -ax"
+nice tar --create --numeric-owner --dereference --directory="$T" --warning=no-file-changed "community-$D" | nice zstd --rsyncable -o "$T/$B"
+nice rsync --preallocate --fuzzy "$T/$B" backup.openstreetmap.org::backup
 
-nice tar --create --numeric-owner --dereference --directory=$T --warning=no-file-changed community-$D | nice gzip --rsyncable -9 > $T/$B
-nice rsync --preallocate --fuzzy $T/$B backup.openstreetmap.org::backup
-
-rm -rf $T
+rm -rf "$T"

--- a/cookbooks/git/templates/default/backup.cron.erb
+++ b/cookbooks/git/templates/default/backup.cron.erb
@@ -2,15 +2,16 @@
 
 # DO NOT EDIT - This file is being maintained by Chef
 
+export ZSTD_CLEVEL=11
+export ZSTD_NBTHREADS=0
+
 T=$(mktemp -d -t -p /var/tmp git.XXXXXXXXXX)
 D=$(date +%Y-%m-%d)
-B=git-$D.tar.gz
+B="git-$D.tar.zst"
 
-ln -s /var/lib/git $T/git-$D
+ln -s /var/lib/git "$T/git-$D"
 
-export RSYNC_RSH="ssh -ax"
+nice tar --create --dereference --directory="$T" "git-$D" | nice zstd --rsyncable -o "$T/$B"
+nice rsync --preallocate --fuzzy "$T/$B" backup.openstreetmap.org::backup
 
-nice tar --create --dereference --directory=$T git-$D | nice gzip --rsyncable -9 > $T/$B
-nice rsync --preallocate --fuzzy $T/$B backup.openstreetmap.org::backup
-
-rm -rf $T
+rm -rf "$T"

--- a/cookbooks/mailman/templates/default/backup.cron.erb
+++ b/cookbooks/mailman/templates/default/backup.cron.erb
@@ -2,16 +2,17 @@
 
 # DO NOT EDIT - This file is being maintained by Chef
 
+export ZSTD_CLEVEL=11
+export ZSTD_NBTHREADS=0
+
 T=$(mktemp -d -t -p /var/tmp lists.XXXXXXXXXX)
 D=$(date +%Y-%m-%d)
-B=lists-$D.tar.gz
+B="lists-$D.tar.zst"
 
-mkdir $T/lists-$D
-ln -s /var/lib/mailman $T/lists-$D/mailman
+mkdir "$T/lists-$D"
+ln -s /var/lib/mailman "$T/lists-$D/mailman"
 
-export RSYNC_RSH="ssh -ax"
+nice tar --create --dereference --warning=no-file-changed --warning=no-file-removed --directory="$T" "lists-$D" | nice zstd --rsyncable -o "$T/$B"
+nice rsync --preallocate --fuzzy "$T/$B" backup.openstreetmap.org::backup
 
-nice tar --create --dereference --warning=no-file-changed --warning=no-file-removed --directory=$T lists-$D | nice gzip --rsyncable -9 > $T/$B
-nice rsync --preallocate --fuzzy $T/$B backup.openstreetmap.org::backup
-
-rm -rf $T
+rm -rf "$T"

--- a/cookbooks/mediawiki/templates/default/mediawiki-backup.cron.erb
+++ b/cookbooks/mediawiki/templates/default/mediawiki-backup.cron.erb
@@ -1,15 +1,27 @@
-#!/bin/bash
-T=`mktemp -d -t -p /var/tmp mediawiki-<%= @name %>.XXXXXXXXXX`
-D=`date +%Y-%m-%d`
-B=wiki-<%= @name %>-$D.tar.gz
+#!/bin/sh
 
-mkdir $T/wiki-<%= @name %>-$D
-echo '[mysqldump]' > $T/mysqldump.opts
-echo 'user=<%= @database_params[:username] %>' >> $T/mysqldump.opts
-echo 'password=<%= @database_params[:password] %>' >> $T/mysqldump.opts
-mysqldump --defaults-file=$T/mysqldump.opts --opt --skip-lock-tables --single-transaction --no-tablespaces "<%= @database_params[:name] %>" | lz4 -9 > $T/wiki-<%= @name %>-$D/wiki.sql.lz4
-ln -s <%= @directory %>  $T/wiki-<%= @name %>-$D/www
-nice tar --create --dereference --directory=$T --warning=no-file-changed --warning=no-file-removed --exclude=wiki-<%= @name %>-$D/www/w/images/thumb --exclude=wiki-<%= @name %>-$D/www/w/.git --exclude=wiki-<%= @name %>-$D/www/w/extensions/*/.git --exclude=wiki-<%= @name %>-$D/www/dump wiki-<%= @name %>-$D | nice gzip --rsyncable -9 > $T/$B
-nice rsync --preallocate --fuzzy $T/$B backup.openstreetmap.org::backup
+# DO NOT EDIT - This file is being maintained by Chef
 
-rm -rf $T
+export ZSTD_CLEVEL=11
+export ZSTD_NBTHREADS=0
+
+T=$(mktemp -d -t -p /var/tmp "mediawiki-<%= @name %>.XXXXXXXXXX")
+D=$(date +%Y-%m-%d)
+B="wiki-<%= @name %>-$D.tar.zst"
+
+mkdir "$T/wiki-<%= @name %>-$D"
+echo '[mysqldump]' > "$T/mysqldump.opts"
+echo 'user=<%= @database_params[:username] %>' >> "$T/mysqldump.opts"
+echo 'password=<%= @database_params[:password] %>' >> "$T/mysqldump.opts"
+mysqldump --defaults-file="$T/mysqldump.opts" --opt --skip-lock-tables --single-transaction --no-tablespaces "<%= @database_params[:name] %>" | zstd --rsyncable -o "$T/wiki-<%= @name %>-$D/wiki.sql.zst"
+ln -s "<%= @directory %>" "$T/wiki-<%= @name %>-$D/www"
+
+nice tar --create --dereference --directory="$T" --warning=no-file-changed --warning=no-file-removed \
+  --exclude="wiki-<%= @name %>-$D/www/w/images/thumb" \
+  --exclude="wiki-<%= @name %>-$D/www/w/.git" \
+  --exclude="wiki-<%= @name %>-$D/www/w/extensions/*/.git" \
+  --exclude="wiki-<%= @name %>-$D/www/dump" \
+  "wiki-<%= @name %>-$D" | nice zstd --rsyncable -o "$T/$B"
+nice rsync --preallocate --fuzzy "$T/$B" backup.openstreetmap.org::backup
+
+rm -rf "$T"

--- a/cookbooks/osqa/templates/default/backup.cron.erb
+++ b/cookbooks/osqa/templates/default/backup.cron.erb
@@ -2,19 +2,20 @@
 
 # DO NOT EDIT - This file is being maintained by Chef
 
+export ZSTD_CLEVEL=11
+export ZSTD_NBTHREADS=0
+
 T=$(mktemp -d -t -p /var/tmp osqa.XXXXXXXXXX)
 D=$(date +%Y-%m-%d)
-B=<%= @name %>-$D.tar.gz
+B="<%= @name %>-$D.tar.zst"
 
-mkdir $T/<%= @name %>-$D
-chown <%= @user %> $T
-chown <%= @user %> $T/osqa-$D
-sudo -u <%= @user %> pg_dump --format=custom --file=$T/<%= @name %>-$D/osqa.dmp <%= @database %>
-ln -s <%= @directory %>/upfiles $T/<%= @name %>-$D/upfiles
+mkdir "$T/<%= @name %>-$D"
+chown "<%= @user %>" "$T"
+chown "<%= @user %>" "$T/osqa-$D"
+sudo -u "<%= @user %>" pg_dump --format=custom --file="$T/<%= @name %>-$D/osqa.dmp" "<%= @database %>"
+ln -s "<%= @directory %>/upfiles" "$T/<%= @name %>-$D/upfiles"
 
-export RSYNC_RSH="ssh -ax"
+nice tar --create --dereference --directory="$T" "<%= @name %>-$D" | nice zstd --rsyncable -o "$T/$B"
+nice rsync --preallocate --fuzzy "$T/$B" backup.openstreetmap.org::backup
 
-nice tar --create --dereference --directory=$T <%= @name %>-$D | nice gzip --rsyncable -9 > $T/$B
-nice rsync --preallocate --fuzzy $T/$B backup.openstreetmap.org::backup
-
-rm -rf $T
+rm -rf "$T"

--- a/cookbooks/otrs/templates/default/backup.cron.erb
+++ b/cookbooks/otrs/templates/default/backup.cron.erb
@@ -2,20 +2,21 @@
 
 # DO NOT EDIT - This file is being maintained by Chef
 
+export ZSTD_CLEVEL=11
+export ZSTD_NBTHREADS=0
+
 T=$(mktemp -d -t -p /var/tmp otrs.XXXXXXXXXX)
 D=$(date +%Y-%m-%d)
-B=otrs-$D.tar.gz
+B="otrs-$D.tar.zst"
 
-mkdir $T/otrs-$D
-chown otrs $T
-chown otrs $T/otrs-$D
-sudo -u otrs pg_dump --file=$T/otrs-$D/otrs.dmp otrs
-ln -s /var/lib/otrs $T/otrs-$D/otrs-var
-ln -s /etc/apache2/sites-available/otrs.openstreetmap.org.conf $T/otrs-$D/apache2-otrs.openstreetmap.org.conf
+mkdir "$T/otrs-$D"
+chown otrs "$T"
+chown otrs "$T/otrs-$D"
+sudo -u otrs pg_dump --file="$T/otrs-$D/otrs.dmp" otrs
+ln -s /var/lib/otrs "$T/otrs-$D/otrs-var"
+ln -s /etc/apache2/sites-available/otrs.openstreetmap.org.conf "$T/otrs-$D/apache2-otrs.openstreetmap.org.conf"
 
-export RSYNC_RSH="ssh -ax"
+nice tar --create --dereference --directory="$T" "otrs-$D" | nice zstd --rsyncable -o "$T/$B"
+nice rsync --preallocate --fuzzy "$T/$B" backup.openstreetmap.org::backup
 
-nice tar --create --dereference --directory=$T otrs-$D | nice gzip --rsyncable -9 > $T/$B
-nice rsync --preallocate --fuzzy $T/$B backup.openstreetmap.org::backup
-
-rm -rf $T
+rm -rf "$T"

--- a/cookbooks/prometheus/templates/default/backup.cron.erb
+++ b/cookbooks/prometheus/templates/default/backup.cron.erb
@@ -2,18 +2,19 @@
 
 # DO NOT EDIT - This file is being maintained by Chef
 
+export ZSTD_CLEVEL=11
+export ZSTD_NBTHREADS=0
+
 T=$(mktemp -d -t -p /var/tmp prometheus.XXXXXXXXXX)
 D=$(date +%Y-%m-%d)
-B=prometheus-$D.tar.gz
+B="prometheus-$D.tar.zst"
 
-mkdir $T/prometheus-$D
+mkdir "$T/prometheus-$D"
 
-ln -s /var/lib/prometheus/alertmanager $T/prometheus-$D/alertmanager
-ln -s /var/lib/grafana $T/prometheus-$D/grafana
+ln -s /var/lib/prometheus/alertmanager "$T/prometheus-$D/alertmanager"
+ln -s /var/lib/grafana "$T/prometheus-$D/grafana"
 
-export RSYNC_RSH="ssh -ax"
+nice tar --create --dereference --directory="$T" "prometheus-$D" | nice zstd --rsyncable -o "$T/$B"
+nice rsync --preallocate --fuzzy "$T/$B" backup.openstreetmap.org::backup
 
-nice tar --create --dereference --directory=$T prometheus-$D | nice gzip --rsyncable -9 > $T/$B
-nice rsync --preallocate --fuzzy $T/$B backup.openstreetmap.org::backup
-
-rm -rf $T
+rm -rf "$T"

--- a/cookbooks/stateofthemap/templates/default/backup.cron.erb
+++ b/cookbooks/stateofthemap/templates/default/backup.cron.erb
@@ -2,26 +2,27 @@
 
 # DO NOT EDIT - This file is being maintained by Chef
 
+export ZSTD_CLEVEL=11
+export ZSTD_NBTHREADS=0
+
 T=$(mktemp -d -t -p /var/tmp sotm.XXXXXXXXXX)
 D=$(date +%Y-%m-%d)
-B=sotm-$D.tar.gz
+B="sotm-$D.tar.zst"
 
-mkdir $T/sotm-$D
+mkdir "$T/sotm-$D"
 
 <% %w(2010 2011 2012).each do |year| -%>
-echo '[mysqldump]' > $T/mysqldump.opts
-echo 'user=sotm<%= year %>' >> $T/mysqldump.opts
-echo 'password=<%= @passwords["sotm#{year}"] %>' >> $T/mysqldump.opts
-mysqldump --defaults-file=$T/mysqldump.opts --opt --no-tablespaces sotm<%= year %> > $T/sotm-$D/sotm<%= year %>.sql
+echo '[mysqldump]' > "$T/mysqldump.opts"
+echo 'user=sotm<%= year %>' >> "$T/mysqldump.opts"
+echo 'password=<%= @passwords["sotm#{year}"] %>' >> "$T/mysqldump.opts"
+mysqldump --defaults-file="$T/mysqldump.opts" --opt --no-tablespaces "sotm<%= year %>" > "$T/sotm-$D/sotm<%= year %>.sql"
 <% end -%>
 
-ln -s /srv/2010.stateofthemap.org $T/sotm-$D/www2010
-ln -s /srv/2011.stateofthemap.org $T/sotm-$D/www2011
-ln -s /srv/2012.stateofthemap.org $T/sotm-$D/www2012
+ln -s /srv/2010.stateofthemap.org "$T/sotm-$D/www2010"
+ln -s /srv/2011.stateofthemap.org "$T/sotm-$D/www2011"
+ln -s /srv/2012.stateofthemap.org "$T/sotm-$D/www2012"
 
-export RSYNC_RSH="ssh -ax"
+nice tar --create --dereference --directory="$T" "sotm-$D" | nice zstd --rsyncable -o "$T/$B"
+nice rsync --preallocate --fuzzy "$T/$B" backup.openstreetmap.org::backup
 
-nice tar --create --dereference --directory=$T sotm-$D | nice gzip --rsyncable -9 > $T/$B
-nice rsync --preallocate --fuzzy $T/$B backup.openstreetmap.org::backup
-
-rm -rf $T
+rm -rf "$T"

--- a/cookbooks/tools/recipes/default.rb
+++ b/cookbooks/tools/recipes/default.rb
@@ -32,6 +32,7 @@ package %w[
   mtr-tiny
   numactl
   pciutils
+  rsync
   rsyslog
   screen
   smartmontools
@@ -42,6 +43,7 @@ package %w[
   usbutils
   vim
   xfsprogs
+  zstd
 ]
 
 service "rsyslog" do


### PR DESCRIPTION
Switch backups to using zstd over gzip.

Use all cores to allow fast backups.

Example: wiki backup is ~75% faster to create and smaller.