### PR TITLE
fix imagery blocklist RegExp for vworld.kr

### DIFF
--- a/cookbooks/web/recipes/rails.rb
+++ b/cookbooks/web/recipes/rails.rb
@@ -158,7 +158,7 @@ rails_port "www.openstreetmap.org" do
     # Current Google imagery URLs have google or googleapis in the domain
     ".*\\.google(apis)?\\..*/.*",
     # Blacklist VWorld
-    "http://xdworld\\.vworld\\.kr:8080/.*",
+    "https?://xdworld\\.vworld\\.kr[/:].*",
     # Blacklist here
     ".*\\.here\\.com[/:].*",
     # Blacklist Mapy.cz


### PR DESCRIPTION
This was mentioned by DWG member Glassman on the OSM US slack. 

It's not a problem with iD, but rather with this RegExp. [cs169222030](https://osm.org/changeset/169222030) is an example that slipped through