### PR TITLE
Restart Apache in a few extra cases. Remove old ssl stapling config

### DIFF
--- a/cookbooks/apache/recipes/default.rb
+++ b/cookbooks/apache/recipes/default.rb
@@ -53,6 +53,7 @@ template "/etc/apache2/ports.conf" do
   owner "root"
   group "root"
   mode "644"
+  notifies :restart, "service[apache2]"
 end
 
 systemd_service "apache2" do
@@ -99,6 +100,8 @@ apache_module "ssl"
 
 apache_conf "ssl" do
   template "ssl.erb"
+  reload_apache false
+  restart_apache true # restart required for shared memory config changes
 end
 
 # Apache should only be started after modules enabled

--- a/cookbooks/apache/resources/conf.rb
+++ b/cookbooks/apache/resources/conf.rb
@@ -26,6 +26,7 @@ property :cookbook, :kind_of => String
 property :template, :kind_of => String, :required => [:create]
 property :variables, :kind_of => Hash, :default => {}
 property :reload_apache, :kind_of => [TrueClass, FalseClass], :default => true
+property :restart_apache, :kind_of => [TrueClass, FalseClass], :default => false
 
 action :create do
   create_conf
@@ -86,4 +87,5 @@ end
 
 def after_created
   notifies :reload, "service[apache2]" if reload_apache
+  notifies :restart, "service[apache2]" if restart_apache
 end

--- a/cookbooks/apache/templates/default/ssl.erb
+++ b/cookbooks/apache/templates/default/ssl.erb
@@ -5,11 +5,4 @@ SSLProtocol All -SSLv2 -SSLv3
 SSLHonorCipherOrder On
 SSLCipherSuite <%= node[:ssl][:openssl_ciphers] %>
 
-SSLUseStapling off
-SSLStaplingResponderTimeout 5
-SSLStaplingErrorCacheTimeout 60
-SSLStaplingReturnResponderErrors off
-SSLStaplingFakeTryLater off
-SSLStaplingCache shmcb:${APACHE_RUN_DIR}/ssl_ocspcache(512000)
-
 Header always set Strict-Transport-Security "<%= node[:ssl][:strict_transport_security] %>" "expr=%{HTTPS} == 'on'"


### PR DESCRIPTION
Apache cannot cleanly restart if changing ports or shared memory, restart if needed.

Use new restart support if SSL config options are changed.