### PR TITLE
nft: Allow select ICMP types

### DIFF
--- a/cookbooks/networking/templates/default/nftables.conf.erb
+++ b/cookbooks/networking/templates/default/nftables.conf.erb
@@ -86,10 +86,12 @@ table inet chef-filter {
     ip saddr @ip-blocklist jump log-and-drop
     ip6 saddr @ip6-blocklist jump log-and-drop
 
+    icmp type { destination-unreachable, time-exceeded } accept
     icmp type { echo-request } update @ratelimit-icmp-echo-ip { ip saddr limit rate 1/second } accept
     icmp type { echo-request } drop
 
     icmpv6 type { nd-neighbor-solicit, nd-neighbor-advert, nd-router-solicit, nd-router-advert } accept
+    icmpv6 type { destination-unreachable, packet-too-big, time-exceeded } accept
     icmpv6 type { echo-request } update @ratelimit-icmp-echo-ip6 { ip6 saddr limit rate 1/second } accept
     icmpv6 type { echo-request } drop
 


### PR DESCRIPTION
Allow additional ICMP message types. We occasionally incorrectly drop some of these.