### PR TITLE
web: Trust fastly proxy IPs

### DIFF
--- a/cookbooks/web/recipes/frontend.rb
+++ b/cookbooks/web/recipes/frontend.rb
@@ -69,9 +69,18 @@ end
 
 cloudflare_ipv6 = IO.read("#{Chef::Config[:file_cache_path]}/cloudflare-ipv6-list").lines.map(&:chomp)
 
+remote_file "#{Chef::Config[:file_cache_path]}/fastly-ip-list.json" do
+  source "https://api.fastly.com/public-ip-list"
+  compile_time true
+  ignore_failure true
+end
+
+fastlyips = JSON.parse(IO.read("#{Chef::Config[:file_cache_path]}/fastly-ip-list.json"))
+
 apache_site "www.openstreetmap.org" do
   template "apache.frontend.erb"
   variables :cloudflare => cloudflare_ipv4 + cloudflare_ipv6,
+            :fastly => fastlyips["addresses"] + fastlyips["ipv6_addresses"],
             :status => node[:web][:status],
             :secret_key_base => web_passwords["secret_key_base"]
 end

--- a/cookbooks/web/templates/default/apache.frontend.erb
+++ b/cookbooks/web/templates/default/apache.frontend.erb
@@ -31,6 +31,10 @@ ErrorLog /var/log/apache2/error.log
 <% @cloudflare.sort.each do |address| -%>
   RemoteIPTrustedProxy <%= address %>
 <% end -%>
+  # Fastly POPs
+<% @fastly.sort.each do |address| -%>
+  RemoteIPTrustedProxy <%= address %>
+<% end -%>
 
   #
   # Turn on various features


### PR DESCRIPTION
Add Fastly proxy IPs to trusted proxy IPs.

I will configure Fastly to pass client IP via `CF-Connecting-IP` for compatibility.