### PR TITLE
web: Add security.txt

### DIFF
--- a/cookbooks/web/recipes/frontend.rb
+++ b/cookbooks/web/recipes/frontend.rb
@@ -53,6 +53,13 @@ remote_directory "#{node[:web][:base_directory]}/static" do
   files_mode "644"
 end
 
+template "#{node[:web][:base_directory]}/static/.well-known/security.txt" do
+  source "security.txt.erb"
+  owner "root"
+  group "root"
+  mode "644"
+end
+
 remote_file "#{Chef::Config[:file_cache_path]}/cloudflare-ipv4-list" do
   source "https://www.cloudflare.com/ips-v4"
   compile_time true

--- a/cookbooks/web/templates/default/apache.frontend.erb
+++ b/cookbooks/web/templates/default/apache.frontend.erb
@@ -180,6 +180,8 @@ ErrorLog /var/log/apache2/error.log
   Alias /openlayers <%= node[:web][:base_directory] %>/static/openlayers
   Alias /funding.json <%= node[:web][:base_directory] %>/static/funding.json
   Alias /.well-known/funding-manifest-urls <%= node[:web][:base_directory] %>/static/.well-known/funding-manifest-urls
+  Alias /.well-known/security.txt <%= node[:web][:base_directory] %>/static/.well-known/security.txt
+  Alias /security.txt <%= node[:web][:base_directory] %>/static/.well-known/security.txt
   RedirectPermanent /stats https://planet.openstreetmap.org/statistics
 
   #

--- a/cookbooks/web/templates/default/security.txt.erb
+++ b/cookbooks/web/templates/default/security.txt.erb
@@ -1,0 +1,10 @@
+<%
+  require "time"
+  target_date = (Time.now.utc + 28*24*60*60).to_date
+  expires_time = Time.utc(target_date.year, target_date.month, target_date.day, 22, 0, 0)
+%>
+Contact: https://github.com/openstreetmap/operations/blob/master/SECURITY.md
+Expires: <%= expires_time.iso8601 %>
+Preferred-Languages: en
+Policy: https://github.com/openstreetmap/operations/blob/master/SECURITY.md
+Canonical: https://www.openstreetmap.org/.well-known/security.txt


### PR DESCRIPTION
Add a basic security.txt pointing to the current contact / policy document.

The `Expires` field is required, normalise to only "update" once per day.