### PR TITLE
Update OSM tile URL

### DIFF
--- a/cookbooks/dev/files/default/ooc/map.js
+++ b/cookbooks/dev/files/default/ooc/map.js
@@ -27,7 +27,7 @@ $(document).ready(function () {
   });
 
   // Add OpenStreetMap layer
-  var osm = L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+  var osm = L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png", {
     attribution: "© <a target=\"_parent\" href=\"https://www.openstreetmap.org\">OpenStreetMap</a> and contributors, under an <a target=\"_parent\" href=\"https://www.openstreetmap.org/copyright\">open license</a>",
     maxZoom: 18
   });

--- a/cookbooks/dns/files/default/html/dns.js
+++ b/cookbooks/dns/files/default/html/dns.js
@@ -3,7 +3,7 @@ function createMap(divName, jsonFile) {
   var map = L.map(divName);
 
   // Add OpenStreetMap layer
-  L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+  L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png", {
     attribution: "© <a target=\"_parent\" href=\"https://www.openstreetmap.org\">OpenStreetMap</a> and contributors, under an <a target=\"_parent\" href=\"https://www.openstreetmap.org/copyright\">open license</a>",
     maxZoom: 18
   }).addTo(map);

--- a/cookbooks/web/files/default/static/openlayers/OpenStreetMap.js
+++ b/cookbooks/web/files/default/static/openlayers/OpenStreetMap.js
@@ -13,11 +13,7 @@ OpenLayers.Layer.OSM.Mapnik = OpenLayers.Class(OpenLayers.Layer.OSM, {
      * options - {Object} Hashtable of extra options to tag onto the layer
      */
     initialize: function(name, options) {
-        var url = [
-            "https://a.tile.openstreetmap.org/${z}/${x}/${y}.png",
-            "https://b.tile.openstreetmap.org/${z}/${x}/${y}.png",
-            "https://c.tile.openstreetmap.org/${z}/${x}/${y}.png"
-        ];
+        var url = 'https://tile.openstreetmap.org/${z}/${x}/${y}.png',
         options = OpenLayers.Util.extend({
             numZoomLevels: 20,
             attribution: "&copy; <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a> contributors",


### PR DESCRIPTION
Updated OSM tile URL in remaining files. See https://github.com/openstreetmap/operations/issues/737

'squashed' last two commits from #844 manually by branching off from previous commit.
assuming this is still clean commit history.
I only use the browser version.