### PR TITLE
Add second GPS database  for dev server

### DIFF
--- a/cookbooks/dev/recipes/default.rb
+++ b/cookbooks/dev/recipes/default.rb
@@ -360,6 +360,7 @@ if node[:postgresql][:clusters][rails_cluster.to_sym]
 
   node[:dev][:rails][:sites].each do |name, details|
     database_name = details[:database] || "apis_#{name}"
+    gps_database_name = "#{database_name}_gps"
     site_name = "#{name}.apis.dev.openstreetmap.org"
     site_directory = "/srv/#{name}.apis.dev.openstreetmap.org"
     log_directory = "#{site_directory}/logs"
@@ -386,6 +387,18 @@ if node[:postgresql][:clusters][rails_cluster.to_sym]
       postgresql_extension "#{database_name}_postgis" do
         cluster rails_cluster
         database database_name
+        extension "postgis"
+        owner "postgres"
+      end
+
+      postgresql_database gps_database_name do
+        cluster rails_cluster
+        owner "apis"
+      end
+
+      postgresql_extension "#{gps_database_name}_postgis" do
+        cluster rails_cluster
+        database gps_database_name
         extension "postgis"
         owner "postgres"
       end
@@ -435,6 +448,9 @@ if node[:postgresql][:clusters][rails_cluster.to_sym]
         database_port node[:postgresql][:clusters][rails_cluster.to_sym][:port]
         database_name database_name
         database_username "apis"
+        gps_database_port node[:postgresql][:clusters][rails_cluster.to_sym][:port]
+        gps_database_name gps_database_name
+        gps_database_username "apis"
         email_from "OpenStreetMap <web@noreply.openstreetmap.org>"
         gpx_dir gpx_directory
         log_path "#{log_directory}/rails.log"
@@ -571,6 +587,11 @@ if node[:postgresql][:clusters][rails_cluster.to_sym]
       end
 
       postgresql_database database_name do
+        action :drop
+        cluster rails_cluster
+      end
+
+      postgresql_database gps_database_name do
         action :drop
         cluster rails_cluster
       end

--- a/cookbooks/web/resources/rails_port.rb
+++ b/cookbooks/web/resources/rails_port.rb
@@ -41,6 +41,11 @@ property :database_port, String
 property :database_name, String
 property :database_username, String
 property :database_password, String
+property :gps_database_host, String
+property :gps_database_port, String
+property :gps_database_name, String
+property :gps_database_username, String
+property :gps_database_password, String
 property :email_from, String
 property :messages_domain, String
 property :gpx_dir, String
@@ -171,7 +176,12 @@ action :create do
               :port => new_resource.database_port,
               :name => new_resource.database_name,
               :username => new_resource.database_username,
-              :password => new_resource.database_password
+              :password => new_resource.database_password,
+              :gps_host => new_resource.gps_database_host,
+              :gps_port => new_resource.gps_database_port,
+              :gps_name => new_resource.gps_database_name,
+              :gps_username => new_resource.gps_database_username,
+              :gps_password => new_resource.gps_database_password
   end
 
   application_yml = edit_file "#{rails_directory}/config/example.application.yml" do |line|

--- a/cookbooks/web/templates/default/database.yml.erb
+++ b/cookbooks/web/templates/default/database.yml.erb
@@ -1,35 +1,77 @@
 # DO NOT EDIT - This file is being maintained by Chef
 
 production:
-  adapter: postgresql
+  primary:
+    adapter: postgresql
 <% if @host -%>
-  host: <%= @host %>
+    host: <%= @host %>
 <% end -%>
 <% if @port -%>
-  port: <%= @port %>
+    port: <%= @port %>
 <% end -%>
-  database: <%= @name %>
-  username: <%= @username %>
+    database: <%= @name %>
+    username: <%= @username %>
 <% if @password -%>
-  password: <%= @password %>
+    password: <%= @password %>
 <% end -%>
-  encoding: utf8
-  variables:
-    statement_timeout: 300s
+    encoding: utf8
+    variables:
+      statement_timeout: 300s
+<% if @gps_name -%>
+  gps:
+    adapter: postgresql
+<% if @gps_host -%>
+    host: <%= @gps_host %>
+<% end -%>
+<% if @gps_port -%>
+    port: <%= @gps_port %>
+<% end -%>
+    database: <%= @gps_name %>
+    username: <%= @gps_username %>
+<% if @gps_password -%>
+    password: <%= @gps_password %>
+<% end -%>
+    encoding: utf8
+    connect_timeout: 3
+    variables:
+      statement_timeout: 300s
+    migrations_paths: db/gps_migrate
+<% end -%>
 
 development:
-  adapter: postgresql
+  primary:
+    adapter: postgresql
 <% if @host -%>
-  host: <%= @host %>
+    host: <%= @host %>
 <% end -%>
 <% if @port -%>
-  port: <%= @port %>
+    port: <%= @port %>
 <% end -%>
-  database: <%= @name %>
-  username: <%= @username %>
+    database: <%= @name %>
+    username: <%= @username %>
 <% if @password -%>
-  password: <%= @password %>
+    password: <%= @password %>
 <% end -%>
-  encoding: utf8
-  variables:
-    statement_timeout: 300s
+    encoding: utf8
+    variables:
+      statement_timeout: 300s
+<% if @gps_name -%>
+  gps:
+    adapter: postgresql
+<% if @gps_host -%>
+    host: <%= @gps_host %>
+<% end -%>
+<% if @gps_port -%>
+    port: <%= @gps_port %>
+<% end -%>
+    database: <%= @gps_name %>
+    username: <%= @gps_username %>
+<% if @gps_password -%>
+    password: <%= @gps_password %>
+<% end -%>
+    encoding: utf8
+    connect_timeout: 3
+    variables:
+      statement_timeout: 300s
+    migrations_paths: db/gps_migrate
+<% end -%>

--- a/roles/dev.rb
+++ b/roles/dev.rb
@@ -129,6 +129,10 @@ default_attributes(
           :revision => "pablobm-devserver",
           :cgimap_repository => "https://github.com/zerebubuth/openstreetmap-cgimap.git",
           :cgimap_revision => "master"
+        },
+        :rub21 => {
+          :repository => "https://github.com/rub21/openstreetmap-website.git",
+          :revision => "gps_db"
         }
       }
     }


### PR DESCRIPTION
@Firefishy This PR adds a second GPS database to the dev server, as the  suggestion in the OPS meeting. Both databases run on the same PostgreSQL server and share the same user. The rails_port resource now accepts a gps_database_name, and the database.yml template was updated to use Rails multi-database config with primary and gps connections. The dev recipe creates and drops the apis_{name}_gps database for each site, with PostGIS and btree_gist extensions. It also adds a new rub21 site pointing to my gps_db branch to test the setup.


About the database.yml edit: this may need to be reset my changes, since it's allowed  that only the maintainer can edit it.

