### PR TITLE
Remove wikidata source

### DIFF
--- a/cookbooks/taginfo/recipes/default.rb
+++ b/cookbooks/taginfo/recipes/default.rb
@@ -176,7 +176,7 @@ node[:taginfo][:sites].each do |site|
     settings["opensearch"]["contact"] = "webmaster@openstreetmap.org"
     settings["paths"]["bin_dir"] = "#{directory}/build/src"
     settings["sources"]["download"] = ""
-    settings["sources"]["create"] = "db languages projects wiki wikidata chronology sw"
+    settings["sources"]["create"] = "db languages projects wiki chronology sw"
     settings["sources"]["db"]["planetfile"] = "/var/lib/planet/planet.osh.pbf"
     settings["sources"]["chronology"]["osm_history_file"] = "/var/lib/planet/planet.osh.pbf"
     settings["tagstats"]["geodistribution"] = "DenseMmapArray"


### PR DESCRIPTION
The second night in a row getting results from wikidata.org failed. I am running several Sparql queries to get information about OSM keys and tags. Probabyl running into some kind of limit.

This information is not that important, but it blocks the taginfo update. So disabling this for the moment seems to be the best short-term solution.