### PR TITLE
Add rub22 and rub23 branches to dev server

### DIFF
--- a/roles/dev.rb
+++ b/roles/dev.rb
@@ -134,11 +134,11 @@ default_attributes(
           :repository => "https://github.com/rub21/openstreetmap-website.git",
           :revision => "gps_db"
         },
-        :rub22 => {
+        :gpsvisibility => {
           :repository => "https://github.com/rub21/openstreetmap-website.git",
           :revision => "simplify-gps-visibility"
         },
-        :rub23 => {
+        :gpxcompression => {
           :repository => "https://github.com/rub21/openstreetmap-website.git",
           :revision => "compress-gpx-uploads"
         }

--- a/roles/dev.rb
+++ b/roles/dev.rb
@@ -133,6 +133,14 @@ default_attributes(
         :rub21 => {
           :repository => "https://github.com/rub21/openstreetmap-website.git",
           :revision => "gps_db"
+        },
+        :rub22 => {
+          :repository => "https://github.com/rub21/openstreetmap-website.git",
+          :revision => "simplify-gps-visibility"
+        },
+        :rub23 => {
+          :repository => "https://github.com/rub21/openstreetmap-website.git",
+          :revision => "compress-gpx-uploads"
         }
       }
     }


### PR DESCRIPTION
I'm adding these two dev sites to test the GPX compression and the new visibility levels.

- Compression of GPX files: https://github.com/openstreetmap/openstreetmap-website/pull/7124

- Visibility levels: https://github.com/openstreetmap/openstreetmap-website/issues/7089 and https://github.com/Rub21/openstreetmap-website/tree/simplify-gps-visibility

It would be good to deploy these branches,  so we can test the changes in a real scenario with large GPX data.