### PR TITLE
db: Skip backup of gps_points table data

### DIFF
--- a/cookbooks/db/templates/default/backup-db.erb
+++ b/cookbooks/db/templates/default/backup-db.erb
@@ -5,6 +5,6 @@
 D=`date +%Y-%m-%d`
 F=/store/backup/osm-${D}.dmp
 
-pg_dump --user=backup --format=custom --file=$F openstreetmap && \
+pg_dump --user=backup --format=custom --exclude-table-data=gps_points --file=$F openstreetmap && \
   rsync --preallocate $F backup.openstreetmap.org::backup && \
   rm -f $F


### PR DESCRIPTION
Skip the backup of `gps_points` table data.

The `gps_points` table data could be re-imported from the source GPX files.

The `gps_points` table data bloats the backup size and directly delays the publishing of the planet data.